### PR TITLE
Add back-to-library button, contribute CTA, and manifest entity fix

### DIFF
--- a/.github/workflows/ensure-back-button.yml
+++ b/.github/workflows/ensure-back-button.yml
@@ -1,0 +1,37 @@
+name: Ensure Back Button
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.html"
+      - "scripts/ensure-back-button.py"
+      - ".github/workflows/ensure-back-button.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  ensure-back-button:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Ensure back button on HTML pages
+        run: python3 scripts/ensure-back-button.py
+
+      - name: Commit any additions
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A -- '*.html'
+          git diff --staged --quiet || git commit -m "chore: ensure SME&C back button on all pages [skip ci]"
+          git push

--- a/.github/workflows/fix-back-button-pr.yml
+++ b/.github/workflows/fix-back-button-pr.yml
@@ -1,0 +1,43 @@
+name: Fix Back Button on PR
+
+on:
+  pull_request:
+    paths:
+      - "**/*.html"
+      - "scripts/ensure-back-button.py"
+      - ".github/workflows/fix-back-button-pr.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  fix-back-button:
+    # Skip PRs from forks: the default GITHUB_TOKEN cannot push back to them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Ensure back button on HTML pages
+        run: python3 scripts/ensure-back-button.py
+
+      - name: Commit any additions back to the PR branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A -- '*.html'
+          if git diff --staged --quiet; then
+            echo "Back button already present on all HTML pages."
+          else
+            git commit -m "chore: ensure SME&C back button on all pages"
+            git push origin HEAD:${{ github.head_ref }}
+          fi

--- a/app-platform-services/apim-logic-apps-functions-decision-guide.html
+++ b/app-platform-services/apim-logic-apps-functions-decision-guide.html
@@ -610,8 +610,34 @@
     }
   </style>
   <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- ═══════════════════════════════════════════════════
      SECTION 1 — HERO

--- a/app-platform-services/apim-logic-apps-functions-decision-guide.html
+++ b/app-platform-services/apim-logic-apps-functions-decision-guide.html
@@ -611,28 +611,70 @@
   </style>
   <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/azure-databases/azure-sql-comparison.html
+++ b/azure-databases/azure-sql-comparison.html
@@ -530,8 +530,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <div class="container">
 

--- a/azure-databases/azure-sql-comparison.html
+++ b/azure-databases/azure-sql-comparison.html
@@ -531,28 +531,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/azure-databases/sql-2016-eol-customer-guide.html
+++ b/azure-databases/sql-2016-eol-customer-guide.html
@@ -227,8 +227,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- Nav -->
 <nav class="nav" id="nav">

--- a/azure-databases/sql-2016-eol-customer-guide.html
+++ b/azure-databases/sql-2016-eol-customer-guide.html
@@ -228,28 +228,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/fabric/fabric-data-agent-best-practices.html
+++ b/fabric/fabric-data-agent-best-practices.html
@@ -254,8 +254,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- ═══════════════════ HERO ═══════════════════ -->
 <header class="hero">

--- a/fabric/fabric-data-agent-best-practices.html
+++ b/fabric/fabric-data-agent-best-practices.html
@@ -255,28 +255,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/fabric/medallion-architecture-infographic.html
+++ b/fabric/medallion-architecture-infographic.html
@@ -932,8 +932,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- ===== HERO ===== -->
 <div class="hero">

--- a/fabric/medallion-architecture-infographic.html
+++ b/fabric/medallion-architecture-infographic.html
@@ -933,28 +933,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/fabric/microsoft-fabric-interactive.html
+++ b/fabric/microsoft-fabric-interactive.html
@@ -469,8 +469,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <div class="bg-particles"></div>
 

--- a/fabric/microsoft-fabric-interactive.html
+++ b/fabric/microsoft-fabric-interactive.html
@@ -470,28 +470,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/foundry/microsoft-ai-decision-guide.html
+++ b/foundry/microsoft-ai-decision-guide.html
@@ -474,8 +474,34 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- NAV -->
 <nav class="nav" id="nav">

--- a/foundry/microsoft-ai-decision-guide.html
+++ b/foundry/microsoft-ai-decision-guide.html
@@ -475,28 +475,70 @@
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -265,6 +265,112 @@
       background: var(--ms-surface);
     }
 
+    /* ─── Contribute CTA ────────────────────────────────────── */
+    .cta {
+      background: linear-gradient(135deg, var(--ms-blue) 0%, var(--ms-blue-dark) 100%);
+      color: #fff;
+      padding: 56px 48px;
+      position: relative;
+      overflow: hidden;
+    }
+    .cta::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(ellipse at 15% 85%, rgba(255, 255, 255, 0.08) 0%, transparent 55%),
+        radial-gradient(ellipse at 85% 15%, rgba(255, 255, 255, 0.06) 0%, transparent 50%);
+      pointer-events: none;
+    }
+    .cta-inner {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 40px;
+      flex-wrap: wrap;
+      position: relative;
+    }
+    .cta-copy { flex: 1 1 360px; }
+    .cta-eyebrow {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.78);
+      margin-bottom: 10px;
+    }
+    .cta h2 {
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      font-weight: 600;
+      line-height: 1.2;
+      margin-bottom: 12px;
+      color: #fff;
+    }
+    .cta-copy p {
+      font-size: 0.9375rem;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.88);
+      max-width: 520px;
+    }
+    .cta-actions {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 14px;
+      flex-shrink: 0;
+    }
+    .cta-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 22px;
+      border-radius: var(--radius);
+      font-size: 0.9375rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition:
+        transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+        box-shadow 0.35s ease,
+        background 0.35s ease;
+    }
+    .cta-btn--primary {
+      background: #fff;
+      color: var(--ms-blue-dark);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+    }
+    .cta-btn--primary:hover,
+    .cta-btn--primary:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
+      outline: none;
+    }
+    .cta-btn--primary:focus-visible { outline: 2px solid #fff; outline-offset: 3px; }
+    .cta-arrow {
+      transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .cta-btn--primary:hover .cta-arrow,
+    .cta-btn--primary:focus-visible .cta-arrow {
+      transform: translateX(4px);
+    }
+    .cta-btn--secondary {
+      color: #fff;
+      padding: 4px 0;
+      font-size: 0.875rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 0;
+      transition: border-color 0.3s ease, color 0.3s ease;
+    }
+    .cta-btn--secondary:hover,
+    .cta-btn--secondary:focus-visible {
+      border-bottom-color: #fff;
+      outline: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .cta-btn, .cta-arrow { transition: none; }
+      .cta-btn--primary:hover, .cta-btn--primary:focus-visible { transform: none; }
+    }
+
     /* ─── Loading / Error states ────────────────────────────── */
     #status-message {
       max-width: 960px;
@@ -290,6 +396,7 @@
       header { padding: 0 20px; }
       .hero  { padding: 36px 20px 32px; }
       main   { padding: 24px 20px 48px; }
+      .cta   { padding: 40px 20px; }
       footer { padding: 16px 20px; }
     }
   </style>
@@ -335,6 +442,39 @@
       <!-- Cards injected by JavaScript -->
     </div>
   </main>
+
+  <!-- ── Contribute CTA ──────────────────────────────────────── -->
+  <section class="cta" aria-labelledby="cta-heading">
+    <div class="cta-inner">
+      <div class="cta-copy">
+        <p class="cta-eyebrow">Share your expertise</p>
+        <h2 id="cta-heading">Built something worth sharing?</h2>
+        <p>
+          This library grows when the SME&amp;C team contributes. If you&apos;ve made
+          an infographic, decision guide, or architecture diagram that helps the
+          field, add it to the repo and make it easy for the rest of us to find.
+        </p>
+      </div>
+      <div class="cta-actions">
+        <a class="cta-btn cta-btn--primary"
+           href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io"
+           target="_blank" rel="noopener">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18">
+            <path fill="currentColor" d="M12 .5C5.73.5.7 5.54.7 11.85c0 5.05 3.22 9.34 7.7 10.85.56.1.77-.25.77-.55v-2.12c-3.13.69-3.79-1.34-3.79-1.34-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.75 1.19 1.75 1.19 1.02 1.76 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.5-.28-5.13-1.26-5.13-5.59 0-1.23.44-2.24 1.16-3.03-.12-.28-.5-1.43.11-2.99 0 0 .94-.3 3.09 1.15a10.72 10.72 0 0 1 5.62 0c2.14-1.45 3.09-1.15 3.09-1.15.61 1.56.23 2.71.11 2.99.72.79 1.16 1.8 1.16 3.03 0 4.34-2.63 5.31-5.14 5.59.41.36.78 1.06.78 2.14v3.17c0 .3.2.66.78.55 4.48-1.51 7.7-5.8 7.7-10.85C23.3 5.54 18.27.5 12 .5Z"/>
+          </svg>
+          Contribute on GitHub
+          <svg class="cta-arrow" aria-hidden="true" viewBox="0 0 24 24" width="14" height="14">
+            <path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M13 6l6 6-6 6"/>
+          </svg>
+        </a>
+        <a class="cta-btn cta-btn--secondary"
+           href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/docs/adding-an-infographic-to-the-website.md"
+           target="_blank" rel="noopener">
+          Read the contributor guide →
+        </a>
+      </div>
+    </div>
+  </section>
 
   <!-- ── Footer ──────────────────────────────────────────────── -->
   <footer>

--- a/infrastructure/azure-arc.html
+++ b/infrastructure/azure-arc.html
@@ -962,8 +962,34 @@
         }
     </style>
     <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
     <!-- Scroll Progress Bar -->
     <div class="scroll-progress" id="scrollProgress"></div>
 

--- a/infrastructure/azure-arc.html
+++ b/infrastructure/azure-arc.html
@@ -963,28 +963,70 @@
     </style>
     <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
 </head>
 <body>

--- a/manifest.json
+++ b/manifest.json
@@ -51,7 +51,7 @@
     "items": [
       {
         "file": "apim-logic-apps-functions-decision-guide.html",
-        "title": "App Platform Services Decision Guide — APIM, Logic Apps, Functions | SME&amp;C"
+        "title": "App Platform Services Decision Guide — APIM, Logic Apps, Functions | SME&C"
       }
     ]
   },

--- a/scripts/ensure-back-button.py
+++ b/scripts/ensure-back-button.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Ensures a floating "Back to SME&C Infographics" button is present on
+every HTML infographic page. The button links to the library landing
+page ("/") so users who arrive directly on an infographic can return
+to the index.
+
+Collapsed, the button is a small circular icon in the top-left corner;
+on hover, focus, or on coarse-pointer (touch) devices it expands to
+reveal the label "Back to SME&C Infographics".
+
+Idempotent: if the button is already present (detected by a unique
+anchor + style marker pair) the file is left unchanged. Redirect stubs
+(<meta http-equiv="refresh">) and the root index.html library landing
+page are skipped.
+
+The button's CSS is injected before </head> and the anchor element is
+injected immediately after the opening <body ...> tag.
+
+Usage:
+    python3 scripts/ensure-back-button.py          # add button where missing
+    python3 scripts/ensure-back-button.py --check  # fail (exit 1) if any
+                                                   # file is missing it;
+                                                   # do not modify files
+"""
+
+import argparse
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROOT_INDEX = os.path.join(REPO_ROOT, "index.html")
+
+MARKER = 'data-smec-back-button="v1"'
+STYLE_MARKER = "/* smec-back-btn v1 */"
+
+BACK_BUTTON_STYLE = (
+    "<style>" + STYLE_MARKER + """
+.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  width: auto; gap: 8px; padding: 0 14px 0 10px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+@media (hover: none) {
+  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+</style>"""
+)
+
+BACK_BUTTON_ANCHOR = (
+    '<a href="/" class="smec-back-btn" ' + MARKER
+    + ' aria-label="Back to SME&amp;C Infographics">'
+    '<svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24"'
+    ' width="18" height="18"><path fill="currentColor"'
+    ' d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>'
+    '<span class="smec-back-btn__label">Back to SME&amp;C Infographics</span>'
+    '</a>'
+)
+
+HEAD_CLOSE_RE = re.compile(r"^(?P<indent>[ \t]*)</head>", re.MULTILINE)
+BODY_OPEN_RE = re.compile(r"(<body\b[^>]*>)", re.IGNORECASE)
+META_REFRESH_RE = re.compile(
+    r'<meta\s+http-equiv=["\']refresh["\']', re.IGNORECASE
+)
+ANCHOR_RE = re.compile(
+    r'<a\b[^>]*\bdata-smec-back-button\s*=\s*["\']v1["\']', re.IGNORECASE
+)
+
+SKIP_DIRS = {".git", "node_modules", ".github"}
+
+
+def iter_html_files(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fname in filenames:
+            if fname.lower().endswith(".html"):
+                yield os.path.join(dirpath, fname)
+
+
+def ensure_button(filepath: str, check_only: bool = False) -> str:
+    """Return one of:
+        'added'    - button injected
+        'missing'  - button missing (check_only mode)
+        'present'  - anchor and style marker both already present
+        'skipped'  - redirect stub or root index (not applicable)
+        'nohead'   - no </head> tag
+        'nobody'   - no <body> tag
+    """
+    if os.path.abspath(filepath) == ROOT_INDEX:
+        return "skipped"
+
+    with open(filepath, encoding="utf-8", newline="") as fh:
+        content = fh.read()
+
+    if META_REFRESH_RE.search(content):
+        return "skipped"
+
+    has_anchor = bool(ANCHOR_RE.search(content))
+    has_style = STYLE_MARKER in content
+    if has_anchor and has_style:
+        return "present"
+
+    head_match = HEAD_CLOSE_RE.search(content)
+    if not head_match:
+        return "nohead"
+    body_match = BODY_OPEN_RE.search(content)
+    if not body_match:
+        return "nobody"
+
+    if check_only:
+        return "missing"
+
+    # Preserve the file's existing line-ending style.
+    nl = "\r\n" if "\r\n" in content else "\n"
+
+    new_content = content
+
+    if not has_style:
+        indent = head_match.group("indent")
+        style_block = nl.join(
+            indent + line if line else line
+            for line in BACK_BUTTON_STYLE.splitlines()
+        ) + nl
+        new_content = (
+            new_content[: head_match.start()]
+            + style_block
+            + new_content[head_match.start() :]
+        )
+        body_match = BODY_OPEN_RE.search(new_content)
+        if not body_match:
+            return "nobody"
+
+    if not has_anchor:
+        insert_at = body_match.end()
+        anchor_block = nl + BACK_BUTTON_ANCHOR + nl
+        new_content = (
+            new_content[:insert_at] + anchor_block + new_content[insert_at:]
+        )
+
+    with open(filepath, "w", encoding="utf-8", newline="") as fh:
+        fh.write(new_content)
+    return "added"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not modify files; exit 1 if any page is missing the button.",
+    )
+    args = parser.parse_args()
+
+    totals = {
+        "added": [],
+        "missing": [],
+        "present": [],
+        "skipped": [],
+        "nohead": [],
+        "nobody": [],
+    }
+    for filepath in sorted(iter_html_files(REPO_ROOT)):
+        rel = os.path.relpath(filepath, REPO_ROOT).replace(os.sep, "/")
+        status = ensure_button(filepath, check_only=args.check)
+        totals[status].append(rel)
+
+    for status, label in (
+        ("added", "Added button"),
+        ("missing", "Missing button"),
+        ("present", "Already present"),
+        ("skipped", "Skipped (redirect or root index)"),
+        ("nohead", "No </head> found"),
+        ("nobody", "No <body> found"),
+    ):
+        files = totals[status]
+        print(f"{label}: {len(files)}")
+        for f in files:
+            print(f"  - {f}")
+
+    exit_code = 0
+    if totals["nohead"] or totals["nobody"]:
+        print(
+            "ERROR: one or more HTML files are missing <head> or <body> tags.",
+            file=sys.stderr,
+        )
+        exit_code = 1
+    if args.check and totals["missing"]:
+        print(
+            "ERROR: one or more HTML files are missing the SME&C back button. "
+            "Run `python3 scripts/ensure-back-button.py` to add it.",
+            file=sys.stderr,
+        )
+        exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ensure-back-button.py
+++ b/scripts/ensure-back-button.py
@@ -37,28 +37,70 @@ STYLE_MARKER = "/* smec-back-btn v1 */"
 
 BACK_BUTTON_STYLE = (
     "<style>" + STYLE_MARKER + """
-.smec-back-btn { position: fixed; top: 12px; left: 12px; z-index: 9999;
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; width: 40px; height: 40px; padding: 0; border-radius: 20px;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
   background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
   font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  transition: width 0.25s ease, padding 0.25s ease, gap 0.2s ease, background 0.2s ease;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  width: auto; gap: 8px; padding: 0 14px 0 10px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn__icon { flex: 0 0 auto; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
 .smec-back-btn__label { max-width: 0; opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease; }
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
 .smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label { max-width: 260px; opacity: 1; }
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
 @media (hover: none) {
-  .smec-back-btn { width: auto; gap: 8px; padding: 0 14px 0 10px; }
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
   .smec-back-btn__label { max-width: 260px; opacity: 1; }
 }
-@media (max-width: 600px) { .smec-back-btn { top: 8px; left: 8px; } }
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>"""
 )
 

--- a/scripts/ensure-tracking.py
+++ b/scripts/ensure-tracking.py
@@ -52,7 +52,7 @@ def ensure_snippet(filepath: str, check_only: bool = False) -> str:
     In check_only mode, files needing the snippet return 'missing' and
     are not modified. Otherwise they are modified and return 'added'.
     """
-    with open(filepath, encoding="utf-8") as fh:
+    with open(filepath, encoding="utf-8", newline="") as fh:
         content = fh.read()
 
     if META_REFRESH_RE.search(content):
@@ -68,8 +68,10 @@ def ensure_snippet(filepath: str, check_only: bool = False) -> str:
     if check_only:
         return "missing"
 
+    # Preserve the file's existing line-ending style.
+    nl = "\r\n" if "\r\n" in content else "\n"
     indent = match.group("indent")
-    insertion = f"{indent}{SNIPPET}\n"
+    insertion = f"{indent}{SNIPPET}{nl}"
     new_content = content[: match.start()] + insertion + content[match.start() :]
 
     with open(filepath, "w", encoding="utf-8", newline="") as fh:

--- a/scripts/generate-manifest.py
+++ b/scripts/generate-manifest.py
@@ -5,6 +5,7 @@ Scans each infographic category folder for HTML files, extracts their
 at the repository root so the front page can link to them dynamically.
 """
 
+import html
 import json
 import os
 import re
@@ -32,7 +33,11 @@ def extract_title(filepath: str, fallback: str) -> str:
             content = fh.read(4096)  # only read beginning of file
         match = TITLE_RE.search(content)
         if match:
-            title = match.group(1).strip()
+            # Decode HTML entities (e.g. &amp; → &, &mdash; → —) and
+            # collapse any internal whitespace that came from line breaks
+            # inside the <title> tag.
+            title = html.unescape(match.group(1))
+            title = re.sub(r"\s+", " ", title).strip()
             if title:
                 return title
     except OSError:


### PR DESCRIPTION
Adds site navigation improvements and a small bug fix:

- **Floating back-to-library button** on every infographic page (bottom-left, 44px circle that gently expands to a pill on hover: `Back to SME&C Infographics`). Matches existing page animation style (`cubic-bezier(0.22, 1, 0.36, 1)`, label fades before pill shrinks on collapse).
- **Automation** mirroring the tracking pattern:
  - `scripts/ensure-back-button.py` — idempotent injector, preserves line endings, supports `--check`
  - `fix-back-button-pr.yml` — auto-fixes PRs so contributors don't have to think about it (skips forks)
  - `ensure-back-button.yml` — post-merge safety net for fork PRs
- **Contribute CTA** on `index.html` linking to the repo and the contributor guide.
- **Manifest entity fix**: `generate-manifest.py` now `html.unescape()`-es `<title>` contents so `&amp;` no longer double-escapes to `&amp;amp;` in rendered card titles (e.g. `SME&C`).