### PR TITLE
Delete 'Next Steps' section from strategy guide

### DIFF
--- a/avd/healthcare-vdi-strategyguide.html
+++ b/avd/healthcare-vdi-strategyguide.html
@@ -1233,48 +1233,6 @@ footer a:hover{text-decoration:underline}
   </div>
 </section>
 
-<!-- ===== NEXT STEPS ===== -->
-<section class="next-steps-section" id="next-steps">
-  <div class="container">
-    <div class="reveal">
-      <div class="section-label">What's Next</div>
-      <div class="section-title">Suggested next steps</div>
-      <div class="section-subtitle">Here's a clear path forward to move from evaluation to pilot.</div>
-    </div>
-    <div class="steps-timeline stagger">
-      <div class="step-item">
-        <div class="step-num">1</div>
-        <h3>Confirm current-state VDI footprint</h3>
-        <p>Map your existing VDI environment and application portfolio</p>
-      </div>
-      <div class="step-item">
-        <div class="step-num">2</div>
-        <h3>Capture persona counts</h3>
-        <p>Gather user population data for licensing math across all personas</p>
-      </div>
-      <div class="step-item">
-        <div class="step-num">3</div>
-        <h3>Scope a 30-day, two-persona POC</h3>
-        <p>Run a proof-of-concept with both W365 and AVD side-by-side</p>
-      </div>
-      <div class="step-item">
-        <div class="step-num">4</div>
-        <h3>Engage deployment support</h3>
-        <p>Connect with Unified offerings, Cloud Accelerate Factory, or a qualified partner</p>
-      </div>
-      <div class="step-item">
-        <div class="step-num">5</div>
-        <h3>Receive pricing &amp; licensing options</h3>
-        <p>Follow-up with pricing, licensing details, and available ECIF options</p>
-      </div>
-    </div>
-    <div class="reveal" style="text-align:center;margin-top:48px">
-      <p style="font-size:16px;font-weight:600">Chris Larson &middot; Digital Specialist, Microsoft</p>
-      <p style="font-size:14px;opacity:.7;margin-top:4px">chlarson@microsoft.com &middot; +1 (701) 433-4647</p>
-    </div>
-  </div>
-</section>
-
 <footer>
   <p>Windows 365 + Azure Virtual Desktop &middot; Healthcare VDI Strategy &middot; Microsoft &copy; 2026</p>
 </footer>


### PR DESCRIPTION
Removed the 'Next Steps' section from the healthcare VDI strategy guide.