### PR TITLE
fix(workflow): use COPILOT_ASSIGN_TOKEN PAT so Copilot agent actually starts on assigned issues

### DIFF
--- a/.github/workflows/copilot-page-review.yml
+++ b/.github/workflows/copilot-page-review.yml
@@ -121,9 +121,11 @@ jobs:
           # Prefer a user-scoped PAT (stored as COPILOT_ASSIGN_TOKEN)
           # so the issue assignment actually triggers the Copilot
           # coding agent. Falls back to the default workflow token,
-          # which will create/assign issues but will NOT start Copilot
-          # work because assignments from `github-actions[bot]` are
-          # ignored by the agent.
+          # under which the script creates issues but intentionally
+          # leaves them unassigned — assignments from
+          # `github-actions[bot]` are ignored by Copilot, so assigning
+          # under GITHUB_TOKEN would silently reproduce the bug this
+          # workflow was rewritten to avoid.
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");

--- a/.github/workflows/copilot-page-review.yml
+++ b/.github/workflows/copilot-page-review.yml
@@ -61,6 +61,12 @@ concurrency:
   group: copilot-page-review
   cancel-in-progress: false
 
+env:
+  # Single source of truth for the per-run issue cap. Used by both the
+  # Python generator (--max-issues) and the JS assignment step
+  # (MAX_ISSUES_PER_RUN) so the two can't drift out of sync.
+  MAX_ISSUES_PER_RUN: "25"
+
 jobs:
   review:
     runs-on: ubuntu-latest
@@ -73,6 +79,41 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Ensure copilot-review label exists
+        # Idempotent: creates the dedup label on first run, no-ops
+        # afterwards. Lets the assignment step filter open issues by
+        # label instead of paging the full repo issue list. Safe to
+        # run on every invocation.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const name = "copilot-review";
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+              });
+              core.info(`Label '${name}' already exists.`);
+            } catch (err) {
+              if (err.status !== 404) {
+                core.warning(`getLabel failed (${err.message}); continuing.`);
+                return;
+              }
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: "8a63d2",
+                  description: "Issues opened by the monthly Copilot page review workflow.",
+                });
+                core.info(`Created label '${name}'.`);
+              } catch (createErr) {
+                core.warning(`Could not create label '${name}' (${createErr.message}); dedup will fall back to scanning all open issues.`);
+              }
+            }
 
       - name: Inventory audit
         run: python3 scripts/audit-pages.py
@@ -96,7 +137,7 @@ jobs:
           ONLY_PREFIX: ${{ inputs.only }}
           MIN_SEVERITY: ${{ inputs.min_severity || 'low' }}
         run: |
-          args=(--min-severity "$MIN_SEVERITY" --max-issues 25)
+          args=(--min-severity "$MIN_SEVERITY" --max-issues "$MAX_ISSUES_PER_RUN")
           if [ -n "$ONLY_PREFIX" ]; then
             args+=(--only "$ONLY_PREFIX")
           fi
@@ -151,7 +192,10 @@ jobs:
             // create in a single run, independent of what the Python
             // script emitted. Prevents runaway auditor output from
             // spamming the repo and burning Copilot premium requests.
-            const MAX_ISSUES_PER_RUN = 25;
+            // Sourced from workflow-level env so the Python generator
+            // and this step share one value.
+            const MAX_ISSUES_PER_RUN =
+              Number.parseInt(process.env.MAX_ISSUES_PER_RUN || "25", 10) || 25;
 
             // Must match ISSUE_MARKER in open-copilot-review-issues.py.
             const ISSUE_MARKER = "<!-- copilot-page-review v1 -->";

--- a/.github/workflows/copilot-page-review.yml
+++ b/.github/workflows/copilot-page-review.yml
@@ -18,14 +18,20 @@ name: Copilot Page Review
 # The default `GITHUB_TOKEN` authenticates as `github-actions[bot]`,
 # and assignments made by a bot actor do NOT cause the Copilot coding
 # agent to start work on the issue (Copilot only reacts to assignments
-# from a real user or a user-authenticated PAT/app token). To actually
-# kick off Copilot from this workflow, create a repo or org secret
-# named `COPILOT_ASSIGN_TOKEN` containing a fine-grained PAT (or
-# GitHub App installation token) for a user who has Copilot access on
-# this repo, with at least `issues: write` and `contents: read`. If
-# the secret is absent the workflow falls back to `GITHUB_TOKEN`,
-# creates and (best-effort) assigns the issue, and logs a warning —
-# Copilot will need a human to re-assign before it starts.
+# from a real user identity). To actually kick off Copilot from this
+# workflow, create a repo or org secret named `COPILOT_ASSIGN_TOKEN`
+# containing a fine-grained PAT owned by a user who has Copilot access
+# on this repo, with scopes `Issues: Read and write`, `Contents: Read`,
+# and `Metadata: Read`. Fine-grained is strongly preferred over a
+# classic PAT (which would grant broad `repo` write).
+#
+# If the secret is absent the workflow falls back to `GITHUB_TOKEN`,
+# creates the issues, and INTENTIONALLY leaves them unassigned so the
+# failure mode is visually obvious in the issue list — rather than
+# reproducing the exact bug this workflow was meant to fix (issues
+# assigned to Copilot that never turn into PRs because the bot-actor
+# assignment is silently ignored). A human can re-assign Copilot
+# manually to unblock, or the PAT secret can be added.
 
 on:
   schedule:
@@ -130,11 +136,12 @@ jobs:
             if (!usingPat) {
               core.warning(
                 "COPILOT_ASSIGN_TOKEN secret is not set; falling back " +
-                "to GITHUB_TOKEN. Issues will be created and (best-" +
-                "effort) assigned, but the Copilot coding agent will " +
-                "NOT auto-start on them because assignments from " +
-                "github-actions[bot] do not trigger the agent. A human " +
-                "needs to re-assign Copilot, or add the PAT secret."
+                "to GITHUB_TOKEN. Issues will be created but left " +
+                "UNASSIGNED — assignments from github-actions[bot] do " +
+                "not trigger the Copilot coding agent, so pretending " +
+                "to assign would reproduce the exact silent-failure " +
+                "this workflow was fixed to avoid. Add the PAT secret, " +
+                "or re-assign Copilot manually on the open issues."
               );
             }
 
@@ -291,7 +298,14 @@ jobs:
               core.info(`Created issue #${issueNumber} for ${entry.path}.`);
               created++;
 
-              if (copilotActorId) {
+              // Only attempt assignment when we have a user-scoped
+              // PAT. Under GITHUB_TOKEN the mutation succeeds but the
+              // Copilot agent never starts work (bot-actor assignments
+              // are ignored), which is the silent failure mode this
+              // workflow was rewritten to avoid. Leaving the issue
+              // unassigned makes the "secret missing" state visually
+              // obvious on the issue list.
+              if (copilotActorId && usingPat) {
                 try {
                   await github.graphql(
                     `mutation($assignableId:ID!, $actorIds:[ID!]!) {
@@ -305,6 +319,11 @@ jobs:
                 } catch (err) {
                   core.warning(`Could not assign Copilot to #${issueNumber} (${err.message}); leaving unassigned.`);
                 }
+              } else if (copilotActorId && !usingPat) {
+                core.info(
+                  `Leaving #${issueNumber} unassigned (no PAT). ` +
+                  `A human can re-assign Copilot to start the agent.`
+                );
               }
             }
 
@@ -318,5 +337,5 @@ jobs:
               .addRaw(`**Issues created:** ${created}`).addBreak()
               .addRaw(`**Skipped (already open):** ${skipped}`).addBreak()
               .addRaw(`**Copilot assignment available:** ${copilotActorId ? "yes" : "no"}`).addBreak()
-              .addRaw(`**Using PAT (will trigger Copilot):** ${usingPat ? "yes" : "no — agent will not auto-start"}`).addBreak();
+              .addRaw(`**Using PAT (will trigger Copilot):** ${usingPat ? "yes" : "no — issues left unassigned"}`).addBreak();
             await summary.write();

--- a/.github/workflows/copilot-page-review.yml
+++ b/.github/workflows/copilot-page-review.yml
@@ -13,6 +13,19 @@ name: Copilot Page Review
 # Copilot assignment is best-effort: if the repo does not have the
 # Copilot coding agent enabled, the issue is still created (unassigned)
 # so a human can pick it up.
+#
+# IMPORTANT — Copilot trigger on assignment:
+# The default `GITHUB_TOKEN` authenticates as `github-actions[bot]`,
+# and assignments made by a bot actor do NOT cause the Copilot coding
+# agent to start work on the issue (Copilot only reacts to assignments
+# from a real user or a user-authenticated PAT/app token). To actually
+# kick off Copilot from this workflow, create a repo or org secret
+# named `COPILOT_ASSIGN_TOKEN` containing a fine-grained PAT (or
+# GitHub App installation token) for a user who has Copilot access on
+# this repo, with at least `issues: write` and `contents: read`. If
+# the secret is absent the workflow falls back to `GITHUB_TOKEN`,
+# creates and (best-effort) assigns the issue, and logs a warning —
+# Copilot will need a human to re-assign before it starts.
 
 on:
   schedule:
@@ -94,10 +107,36 @@ jobs:
 
       - name: Open issues and assign Copilot
         uses: actions/github-script@v7
+        env:
+          # Surface a boolean into the script — secrets.* can't be
+          # referenced from inside the JS, so we compute presence here.
+          USING_COPILOT_PAT: ${{ secrets.COPILOT_ASSIGN_TOKEN != '' }}
         with:
+          # Prefer a user-scoped PAT (stored as COPILOT_ASSIGN_TOKEN)
+          # so the issue assignment actually triggers the Copilot
+          # coding agent. Falls back to the default workflow token,
+          # which will create/assign issues but will NOT start Copilot
+          # work because assignments from `github-actions[bot]` are
+          # ignored by the agent.
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
             const path = require("path");
+
+            // Whether the caller supplied a user-scoped PAT. We can't
+            // read `secrets.*` from inside the script (by design), so
+            // the workflow env surfaces a boolean instead.
+            const usingPat = process.env.USING_COPILOT_PAT === "true";
+            if (!usingPat) {
+              core.warning(
+                "COPILOT_ASSIGN_TOKEN secret is not set; falling back " +
+                "to GITHUB_TOKEN. Issues will be created and (best-" +
+                "effort) assigned, but the Copilot coding agent will " +
+                "NOT auto-start on them because assignments from " +
+                "github-actions[bot] do not trigger the agent. A human " +
+                "needs to re-assign Copilot, or add the PAT secret."
+              );
+            }
 
             // Hard ceiling on how many issues this step will ever
             // create in a single run, independent of what the Python
@@ -278,5 +317,6 @@ jobs:
               .addRaw(`**Pages with findings:** ${entries.length}`).addBreak()
               .addRaw(`**Issues created:** ${created}`).addBreak()
               .addRaw(`**Skipped (already open):** ${skipped}`).addBreak()
-              .addRaw(`**Copilot assignment available:** ${copilotActorId ? "yes" : "no"}`).addBreak();
+              .addRaw(`**Copilot assignment available:** ${copilotActorId ? "yes" : "no"}`).addBreak()
+              .addRaw(`**Using PAT (will trigger Copilot):** ${usingPat ? "yes" : "no — agent will not auto-start"}`).addBreak();
             await summary.write();

--- a/docs/automated-page-updates.md
+++ b/docs/automated-page-updates.md
@@ -134,10 +134,21 @@ Findings from each phase are appended below as the spike progresses.
   issue titled `Review <path>` (deduped against existing open issues)
   and assigns the Copilot coding agent via the GraphQL
   `replaceActorsForAssignable` mutation. Copilot then opens a draft
-  PR per issue; humans review and merge. No repo secrets needed — the
-  workflow runs under `${{ github.token }}`. If the Copilot coding
-  agent isn't enabled on the repo the issues are still created,
-  unassigned, so a human can pick them up.
+  PR per issue; humans review and merge. If the Copilot coding agent
+  isn't enabled on the repo the issues are still created, unassigned,
+  so a human can pick them up.
+
+  **Token requirement for Copilot auto-start:** assignments made by
+  `github-actions[bot]` (which is what `${{ secrets.GITHUB_TOKEN }}`
+  authenticates as) do **not** trigger the Copilot coding agent to
+  start work — same design reason `GITHUB_TOKEN` events don't cascade
+  into other workflows. To actually kick off Copilot from this
+  workflow, create a repo or org secret named `COPILOT_ASSIGN_TOKEN`
+  containing a fine-grained PAT (or GitHub App installation token)
+  for a user who has Copilot access on this repo. Required scopes:
+  `issues: write`, `contents: read`, `metadata: read`. The workflow
+  prefers this secret and falls back to `GITHUB_TOKEN` with a log
+  warning + step-summary note if it is absent.
 
 ### Outstanding decisions / follow-ups
 
@@ -149,8 +160,10 @@ Findings from each phase are appended below as the spike progresses.
    post-merge (would need `check-deprecated-terms.py --apply` in
    `ensure-site-chrome.yml`; currently PR-only reporting).
 4. Confirm the Copilot coding agent is enabled on the repo before the
-   first scheduled run of `copilot-page-review.yml`. If it isn't, the
-   workflow still opens issues, just unassigned.
+   first scheduled run of `copilot-page-review.yml`, **and** create
+   the `COPILOT_ASSIGN_TOKEN` secret (fine-grained PAT, `issues: write`
+   + `contents: read` + `metadata: read`) — otherwise issues are
+   created but Copilot does not auto-start on them.
 5. Tune the per-page issue body in `open-copilot-review-issues.py`
    after the first real Copilot PR — especially the guardrails block,
    which is the agent's primary steering signal.

--- a/docs/automated-page-updates.md
+++ b/docs/automated-page-updates.md
@@ -144,11 +144,16 @@ Findings from each phase are appended below as the spike progresses.
   start work — same design reason `GITHUB_TOKEN` events don't cascade
   into other workflows. To actually kick off Copilot from this
   workflow, create a repo or org secret named `COPILOT_ASSIGN_TOKEN`
-  containing a fine-grained PAT (or GitHub App installation token)
-  for a user who has Copilot access on this repo. Required scopes:
-  `issues: write`, `contents: read`, `metadata: read`. The workflow
-  prefers this secret and falls back to `GITHUB_TOKEN` with a log
-  warning + step-summary note if it is absent.
+  containing a **fine-grained PAT** owned by a user who has Copilot
+  access on this repo. Required scopes: `Issues: Read and write`,
+  `Contents: Read`, `Metadata: Read`. Fine-grained is strongly
+  preferred over a classic PAT (which would grant broad `repo` write).
+  When the secret is absent the workflow still runs: it creates the
+  issues and **intentionally leaves them unassigned**, emits a
+  `core.warning`, and flags it in the step summary — rather than
+  assigning under `GITHUB_TOKEN` and silently reproducing the exact
+  bug this setup was meant to fix. A human can re-assign Copilot
+  manually to unblock, or the PAT secret can be added.
 
 ### Outstanding decisions / follow-ups
 


### PR DESCRIPTION
## What this PR does

Fixes the silent failure where the monthly `copilot-page-review` workflow created issues and "assigned" Copilot, but the Copilot coding agent never actually picked them up — so no draft PRs ever appeared.

**Root cause:** the `Open issues and assign Copilot` step ran under `GITHUB_TOKEN`, which authenticates as `github-actions[bot]`. Copilot's coding agent ignores assignments made by a bot actor (same design rule that prevents `GITHUB_TOKEN` events cascading into other workflows). The `replaceActorsForAssignable` mutation succeeds, the issue shows Copilot as assignee, but the agent is never notified.

**Fix:** the assignment step now prefers a user-scoped PAT via `github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}`. When the PAT is present, the assignment is made under a real user identity and Copilot starts work as designed.

**Safe-by-default fallback:** if the secret is missing, the workflow still runs — it creates the issues but **intentionally leaves them unassigned**, emits a loud `core.warning`, and flags it in the step summary. That makes the "secret missing" state visually obvious instead of silently reproducing the original bug.

**Small tidy-ups folded in while I was here:**
- Auto-create the `copilot-review` dedup label on first run (idempotent step), so the open-issues query can use the fast label-filtered path immediately.
- Unify the per-run issue cap (`25`) into a single workflow-level `env`, consumed by both the Python generator (`--max-issues`) and the JS step (`MAX_ISSUES_PER_RUN`), so the two can't drift.

## Post-merge actions (required to actually trigger Copilot)

1. **Create the secret `COPILOT_ASSIGN_TOKEN`** on the repo (or org, scoped to this repo). Use a **fine-grained PAT** owned by a user with Copilot access here. Required scopes:
   - `Issues: Read and write`
   - `Contents: Read`
   - `Metadata: Read`

   Fine-grained is strongly preferred over a classic PAT (which would grant broad `repo` write).
2. **Confirm the Copilot coding agent is enabled** on the repo (Settings → Copilot → Coding agent).

Without step 1 the workflow will run safely but leave issues unassigned. Without step 2 issues are created but Copilot is not an assignable actor, and the script logs that and continues.

## How to test

After merging and completing both post-merge steps:

1. Go to **Actions → Copilot Page Review → Run workflow**.
2. Set `only: foundry/` to scope the smoke test to a single directory (avoids opening 25 issues on the first try).
3. Expect:
   - 1 issue created with the `copilot-review` label and `<!-- copilot-page-review v1 -->` marker.
   - Copilot listed as assignee.
   - A draft PR opened by Copilot against that issue within a few minutes.
   - Step summary shows `Copilot assignment available: yes`.

**Negative test (optional):** delete the secret, dispatch again on a different scope. Expect: issue created, **unassigned**, with a `core.warning` in the log and a step-summary line flagging the missing PAT. This is the safe-fallback path.

If issues are created and assigned but no draft PR appears, that points to step 2 (Copilot coding agent enablement), not this workflow.

## Other review pass

Re-read the merged workflow, the Python generator, and the companion audit workflows. Nothing else looked broken — idempotency markers, per-section caps, body-size guard, dedup by `<!-- page: ... -->` marker, label-aware open-issues query, and the `workflow_run` split in `audit-site-comment.yml` for fork PRs all look correct. Token mismatch was the only substantive issue.



## Security &amp; long-term maintenance notes

**Why this is safe to ship today**
- Fine-grained PAT, scoped to this single repo, minimum permissions (`Issues: write`, `Contents: read`, `Metadata: read`) — far narrower than a classic PAT.
- Stored as an Actions secret (masked in logs, never exposed to fork PRs — workflow only runs on `schedule` and `workflow_dispatch`).
- Used by first-party code in this repo, not handed off to a third-party action.
- Safe-fallback: if the secret is missing or revoked, the workflow degrades to "create issues unassigned" with a loud warning. No silent failure.
- This is the documented GitHub-recommended pattern for triggering Copilot from automation; there is no first-party "use the GitHub App identity" alternative today.
- Public repo, no production deploys gated on these issues, monthly cadence with a 25-issue cap → low blast radius.

**Long-term maintenance items to track**
1. **PAT is tied to a human account.** If that user leaves, loses Copilot access, or is compromised, the workflow breaks (or an attacker inherits the token). *Mitigation:* use a dedicated bot/service account if org policy allows, instead of a personal one.
2. **Fine-grained PATs expire (max 1 year).** When it expires the workflow silently falls back to "unassigned" mode — not catastrophic, but monthly automation pauses until someone notices. *Mitigation:* calendar reminder ~11 months out for rotation.
3. **Cosmetic audit-trail change.** The PAT user becomes the "assigner of record" on every auto-created issue, instead of `github-actions[bot]`. Visible in issue history; no functional impact.
4. **Token-leak blast radius.** Even narrowly scoped, a leaked token can open/modify issues and read repo contents. For a public infographics site that is low-impact, but worth noting.
5. **Future-proofing option:** if PAT rotation becomes annoying or the human-account dependency feels fragile, swap to a **GitHub App installation token** in a follow-up PR. Same security posture, no human-account ties, no expiration treadmill.