### PR TITLE
feat: add weekly accuracy review workflow with Copilot assignment

### DIFF
--- a/.github/workflows/accuracy-review-merge.yml
+++ b/.github/workflows/accuracy-review-merge.yml
@@ -1,0 +1,88 @@
+name: Stamp Accuracy Review Date
+
+# Post-merge stamper. When a pull request labelled `accuracy-review`
+# is merged into `main`, this workflow updates the
+# `smec:last-accuracy-check` meta tag on every HTML file the PR
+# touched to today's UTC date, then commits the change back. This
+# guarantees the recorded review date reflects the merge time, not
+# the time the Copilot coding agent first opened the PR — so a slow
+# review doesn't shorten the next 28-day cycle incorrectly.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stamp-accuracy-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  stamp:
+    # Only run when the PR was actually merged AND it carried the
+    # `accuracy-review` label. `pull_request: closed` also fires for
+    # closed-without-merge, which we ignore.
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'accuracy-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          # Need write access from the workflow token; default checkout
+          # depth is fine because we only commit on top of HEAD.
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Collect changed HTML files
+        id: changed
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Pull the file list from the PR via the API rather than
+          # diffing locally — the merge commit may include unrelated
+          # work and we want exactly what the PR changed.
+          gh api \
+            --paginate \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' \
+            | grep -E '\.html$' \
+            | sort -u \
+            > changed-html.txt || true
+          echo "Changed HTML files:"
+          cat changed-html.txt || true
+          if [ ! -s changed-html.txt ]; then
+            echo "no_html=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stamp accuracy date
+        if: steps.changed.outputs.no_html != 'true'
+        run: |
+          # Pass the file list as positional args. xargs -r avoids
+          # invoking the script with no args if the file is empty
+          # (defensive; the prior step already guards this case).
+          xargs -r -a changed-html.txt python3 scripts/stamp-accuracy-date.py
+
+      - name: Commit any updates
+        if: steps.changed.outputs.no_html != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A -- '*.html'
+          if git diff --staged --quiet; then
+            echo "No accuracy-date changes to commit."
+          else
+            git commit -m "chore: stamp accuracy-review date for #${{ github.event.pull_request.number }} [skip ci]"
+            git push
+          fi

--- a/.github/workflows/accuracy-review.yml
+++ b/.github/workflows/accuracy-review.yml
@@ -1,0 +1,338 @@
+name: Accuracy Review
+
+# Weekly scan that opens a Copilot-assigned GitHub issue for any
+# infographic whose `smec:last-accuracy-check` meta tag is missing or
+# older than 28 days. Copilot is asked to verify the page against the
+# current Microsoft Learn documentation and submit a draft PR with
+# corrections (and citations) — or, if the page is already accurate,
+# a metadata-only PR that just refreshes the marker block.
+#
+# Schedule note: deliberately runs on Thursdays so it does not collide
+# with `copilot-page-review.yml` (which runs at 07:00 UTC on the 1st
+# of every month). The dedup logic below also looks for open issues
+# created by the monthly review workflow so that the two workflows
+# never queue duplicate Copilot work for the same file.
+#
+# IMPORTANT — Copilot trigger on assignment:
+# The default `GITHUB_TOKEN` authenticates as `github-actions[bot]`,
+# and assignments made by a bot actor do NOT cause the Copilot coding
+# agent to start work on the issue. To kick off Copilot from this
+# workflow, configure the repo/org secret `COPILOT_ASSIGN_TOKEN` as
+# documented on `copilot-page-review.yml`. Without the secret, issues
+# are created but intentionally left unassigned so the failure mode
+# is visible.
+
+on:
+  schedule:
+    # 07:00 UTC every Thursday.
+    - cron: "0 7 * * 4"
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Optional path prefix to restrict the scan (e.g. fabric/)."
+        required: false
+        default: ""
+      max_age_days:
+        description: "Flag pages older than this many days (default 28)."
+        required: false
+        default: "28"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: accuracy-review
+  cancel-in-progress: false
+
+env:
+  # Single source of truth for the per-run issue cap. Used by both the
+  # Python generator (--max-issues) and the JS assignment step
+  # (MAX_ISSUES_PER_RUN) so the two can't drift out of sync. Lower
+  # than the monthly review cap (25) because this workflow runs
+  # weekly and we want the initial wave of legacy pages to roll
+  # through over several weeks rather than landing all at once.
+  MAX_ISSUES_PER_RUN: "10"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Ensure accuracy-review label exists
+        # Idempotent: creates the dedup label on first run, no-ops
+        # afterwards. Lets the assignment step filter open issues by
+        # label instead of paging the full repo issue list.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const name = "accuracy-review";
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+              });
+              core.info(`Label '${name}' already exists.`);
+            } catch (err) {
+              if (err.status !== 404) {
+                core.warning(`getLabel failed (${err.message}); continuing.`);
+                return;
+              }
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: "0e8a16",
+                  description: "Issues opened by the weekly accuracy-review workflow.",
+                });
+                core.info(`Created label '${name}'.`);
+              } catch (createErr) {
+                core.warning(`Could not create label '${name}' (${createErr.message}); dedup will fall back to scanning all open issues.`);
+              }
+            }
+
+      - name: Build accuracy review issue bodies
+        env:
+          ONLY_PREFIX: ${{ inputs.only }}
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '28' }}
+        run: |
+          args=(--max-age-days "$MAX_AGE_DAYS" --max-issues "$MAX_ISSUES_PER_RUN")
+          if [ -n "$ONLY_PREFIX" ]; then
+            args+=(--only "$ONLY_PREFIX")
+          fi
+          python3 scripts/check-accuracy-staleness.py "${args[@]}"
+
+      - name: Upload review bodies as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: accuracy-review-issues
+          path: |
+            reports/accuracy-review-issues/*.md
+            reports/accuracy-review-issues/index.json
+          if-no-files-found: ignore
+
+      - name: Open issues and assign Copilot
+        uses: actions/github-script@v7
+        env:
+          USING_COPILOT_PAT: ${{ secrets.COPILOT_ASSIGN_TOKEN != '' }}
+        with:
+          # Prefer a user-scoped PAT so the issue assignment actually
+          # triggers the Copilot coding agent. See
+          # `copilot-page-review.yml` for the rationale.
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const usingPat = process.env.USING_COPILOT_PAT === "true";
+            if (!usingPat) {
+              core.warning(
+                "COPILOT_ASSIGN_TOKEN secret is not set; falling back " +
+                "to GITHUB_TOKEN. Issues will be created but left " +
+                "UNASSIGNED — assignments from github-actions[bot] do " +
+                "not trigger the Copilot coding agent."
+              );
+            }
+
+            const MAX_ISSUES_PER_RUN =
+              Number.parseInt(process.env.MAX_ISSUES_PER_RUN || "10", 10) || 10;
+
+            // Must match ISSUE_MARKER in check-accuracy-staleness.py.
+            const ISSUE_MARKER = "<!-- copilot-accuracy-review v1 -->";
+            const DEDUP_LABEL = "accuracy-review";
+            // Cross-workflow dedup: also skip pages already queued by
+            // the monthly content review workflow so we don't open
+            // two Copilot issues for the same file.
+            const SIBLING_LABEL = "copilot-review";
+            const SIBLING_MARKER = "<!-- copilot-page-review v1 -->";
+
+            const dir = "reports/accuracy-review-issues";
+            const indexPath = path.join(dir, "index.json");
+            if (!fs.existsSync(indexPath)) {
+              core.info("No index.json; nothing to do.");
+              return;
+            }
+            const index = JSON.parse(fs.readFileSync(indexPath, "utf8"));
+            const entries = Array.isArray(index.issues) ? index.issues : [];
+            if (!entries.length) {
+              core.info("No stale pages; nothing to do.");
+              return;
+            }
+
+            // Resolve preferred labels that actually exist on the repo.
+            const preferredLabels = ["content-freshness", "automated", DEDUP_LABEL];
+            let labelsToUse = [];
+            const existingLabelNames = new Set();
+            try {
+              const existing = await github.paginate(
+                github.rest.issues.listLabelsForRepo,
+                { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+              );
+              for (const l of existing) existingLabelNames.add(l.name);
+              labelsToUse = preferredLabels.filter(n => existingLabelNames.has(n));
+            } catch (err) {
+              core.info(`Could not list labels (${err.message}); creating issues without labels.`);
+            }
+            const hasDedupLabel = existingLabelNames.has(DEDUP_LABEL);
+            const hasSiblingLabel = existingLabelNames.has(SIBLING_LABEL);
+
+            // Collect existing open issues for dedup. Look at both our
+            // own label and the monthly-review label so the same page
+            // is never queued twice.
+            async function listOpenWithLabel(label) {
+              if (!label) return [];
+              try {
+                return await github.paginate(
+                  github.rest.issues.listForRepo,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: "open",
+                    per_page: 100,
+                    labels: label,
+                  }
+                );
+              } catch (err) {
+                core.info(`Could not list open issues for label '${label}' (${err.message}).`);
+                return [];
+              }
+            }
+
+            const openByPath = new Map();
+            const ownOpen = hasDedupLabel ? await listOpenWithLabel(DEDUP_LABEL) : [];
+            const siblingOpen = hasSiblingLabel ? await listOpenWithLabel(SIBLING_LABEL) : [];
+            for (const issue of [...ownOpen, ...siblingOpen]) {
+              if (issue.pull_request) continue;
+              const body = issue.body || "";
+              if (!body.includes(ISSUE_MARKER) && !body.includes(SIBLING_MARKER)) continue;
+              const m = body.match(/<!-- page: ([^>]+?) -->/);
+              if (m) {
+                openByPath.set(m[1].trim(), issue.number);
+              }
+            }
+
+            // Look up Copilot's assignable actor id once.
+            let copilotActorId = null;
+            try {
+              const q = `
+                query($owner:String!, $repo:String!) {
+                  repository(owner:$owner, name:$repo) {
+                    suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100) {
+                      nodes {
+                        login
+                        __typename
+                        ... on Bot { id }
+                        ... on User { id }
+                      }
+                    }
+                  }
+                }
+              `;
+              const result = await github.graphql(q, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              const nodes = result?.repository?.suggestedActors?.nodes || [];
+              const copilot = nodes.find(n =>
+                n && n.__typename === "Bot" &&
+                (n.login === "copilot-swe-agent" || n.login === "Copilot")
+              );
+              if (copilot?.id) {
+                copilotActorId = copilot.id;
+                core.info(`Found Copilot assignable actor (${copilot.login}).`);
+              } else {
+                core.info("Copilot coding agent not available as an assignee on this repo.");
+              }
+            } catch (err) {
+              core.info(`Could not query suggestedActors (${err.message}); continuing without Copilot assignment.`);
+            }
+
+            let created = 0;
+            let skipped = 0;
+
+            for (const entry of entries) {
+              if (created >= MAX_ISSUES_PER_RUN) {
+                core.warning(`Reached MAX_ISSUES_PER_RUN (${MAX_ISSUES_PER_RUN}); stopping.`);
+                break;
+              }
+              if (!entry || typeof entry.path !== "string" || typeof entry.body_file !== "string") {
+                core.info("Skipping malformed index entry.");
+                continue;
+              }
+              const title = `Accuracy review: \`${entry.path}\``;
+              const safeBodyName = path.basename(entry.body_file);
+              const bodyPath = path.join(dir, safeBodyName);
+              if (!fs.existsSync(bodyPath)) {
+                core.info(`Missing body file for ${entry.path}; skipping.`);
+                continue;
+              }
+              const body = fs.readFileSync(bodyPath, "utf8");
+              if (!body.includes(ISSUE_MARKER)) {
+                core.info(`Body for ${entry.path} missing expected marker; skipping.`);
+                continue;
+              }
+
+              const existingNumber = openByPath.get(entry.path);
+              if (existingNumber) {
+                core.info(`Open issue already exists for ${entry.path}: #${existingNumber}`);
+                skipped++;
+                continue;
+              }
+
+              const issueParams = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              };
+              if (labelsToUse.length) {
+                issueParams.labels = labelsToUse;
+              }
+              const createResp = await github.rest.issues.create(issueParams);
+              const issueNumber = createResp.data.number;
+              const issueNodeId = createResp.data.node_id;
+              core.info(`Created issue #${issueNumber} for ${entry.path}.`);
+              created++;
+
+              if (copilotActorId && usingPat) {
+                try {
+                  await github.graphql(
+                    `mutation($assignableId:ID!, $actorIds:[ID!]!) {
+                       replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}) {
+                         assignable { ... on Issue { number } }
+                       }
+                     }`,
+                    { assignableId: issueNodeId, actorIds: [copilotActorId] }
+                  );
+                  core.info(`Assigned Copilot to #${issueNumber}.`);
+                } catch (err) {
+                  core.warning(`Could not assign Copilot to #${issueNumber} (${err.message}); leaving unassigned.`);
+                }
+              } else if (copilotActorId && !usingPat) {
+                core.info(
+                  `Leaving #${issueNumber} unassigned (no PAT). ` +
+                  `A human can re-assign Copilot to start the agent.`
+                );
+              }
+            }
+
+            core.info(`Done. created=${created} skipped_existing=${skipped}`);
+
+            const summary = core.summary
+              .addHeading("Accuracy Review", 2)
+              .addRaw(`**Stale pages found:** ${entries.length}`).addBreak()
+              .addRaw(`**Issues created:** ${created}`).addBreak()
+              .addRaw(`**Skipped (already open):** ${skipped}`).addBreak()
+              .addRaw(`**Copilot assignment available:** ${copilotActorId ? "yes" : "no"}`).addBreak()
+              .addRaw(`**Using PAT (will trigger Copilot):** ${usingPat ? "yes" : "no — issues left unassigned"}`).addBreak();
+            await summary.write();

--- a/scripts/check-accuracy-staleness.py
+++ b/scripts/check-accuracy-staleness.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Find HTML infographics whose documented "last accuracy check" date is
+missing or older than the configured threshold, and emit one markdown
+issue body per stale page into reports/accuracy-review-issues/.
+
+Each page is expected to carry a meta tag of the form:
+
+    <!-- smec-accuracy v1 -->
+    <meta name="smec:last-accuracy-check" content="YYYY-MM-DD">
+
+Pages without the marker are treated as "never reviewed" and become
+immediately eligible — that is intentional so legacy pages roll
+through the review cycle naturally without a separate bootstrap step.
+The per-run cap (--max-issues) throttles the initial wave.
+
+This script does not modify any HTML and does not call any LLM. The
+companion workflow `.github/workflows/accuracy-review.yml` reads the
+generated `index.json`, opens GitHub issues, and assigns the Copilot
+coding agent. Mirrors the structure of
+`scripts/open-copilot-review-issues.py`.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+from typing import Any
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROOT_INDEX = os.path.join(REPO_ROOT, "index.html")
+REPORTS_DIR = os.path.join(REPO_ROOT, "reports")
+OUT_DIR = os.path.join(REPORTS_DIR, "accuracy-review-issues")
+
+# Hidden marker embedded in each issue body so the workflow can dedup
+# reliably (issue-title search is tokenized and misses backticks). The
+# workflow searches open issues by label and checks the body for this
+# marker + the file path before creating a duplicate.
+ISSUE_MARKER = "<!-- copilot-accuracy-review v1 -->"
+
+META_NAME = "smec:last-accuracy-check"
+META_BLOCK_MARKER = "<!-- smec-accuracy v1 -->"
+
+ACCURACY_META_RE = re.compile(
+    r'<meta\s+[^>]*name=["\']' + re.escape(META_NAME)
+    + r'["\'][^>]*content=["\']([^"\']*)["\']',
+    re.IGNORECASE,
+)
+TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+META_REFRESH_RE = re.compile(
+    r'<meta\s+http-equiv=["\']refresh["\']', re.IGNORECASE
+)
+
+SKIP_DIRS = {".git", "node_modules", ".github", "reports"}
+
+# GitHub issue body hard limit is 65536 chars; stay well below.
+MAX_BODY_CHARS = 60000
+
+
+def iter_html_files(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fname in filenames:
+            if fname.lower().endswith(".html"):
+                yield os.path.join(dirpath, fname)
+
+
+def _extract_title(content: str, fallback: str) -> str:
+    m = TITLE_RE.search(content)
+    if not m:
+        return fallback
+    raw = re.sub(r"\s+", " ", m.group(1)).strip()
+    return raw or fallback
+
+
+def _sanitize_title(title: str) -> str:
+    # Strip characters that could terminate a markdown code span or
+    # inject markdown structure so the title renders as literal text.
+    return re.sub(r"[`<>]", "", title).strip() or "(untitled)"
+
+
+def _parse_date(value: str) -> dt.date | None:
+    value = (value or "").strip()
+    if not value:
+        return None
+    try:
+        return dt.date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _classify(filepath: str, today: dt.date,
+              max_age_days: int) -> tuple[str, dt.date | None, int | None]:
+    """Return (status, last_check_date, age_days).
+
+    status is one of:
+      - "missing"   : no marker / no parseable date
+      - "stale"     : last check older than max_age_days
+      - "fresh"     : within the threshold
+      - "skipped"   : redirect stub / root index
+    """
+    if os.path.abspath(filepath) == os.path.abspath(ROOT_INDEX):
+        return "skipped", None, None
+    with open(filepath, encoding="utf-8") as fh:
+        content = fh.read()
+    if META_REFRESH_RE.search(content):
+        return "skipped", None, None
+    m = ACCURACY_META_RE.search(content)
+    if not m:
+        return "missing", None, None
+    last = _parse_date(m.group(1))
+    if last is None:
+        return "missing", None, None
+    age = (today - last).days
+    if age > max_age_days:
+        return "stale", last, age
+    return "fresh", last, age
+
+
+def _render(rel: str, title: str, last_check: dt.date | None,
+            age_days: int | None, max_age_days: int) -> str:
+    safe_title = _sanitize_title(title)
+    if last_check is None:
+        freshness_line = (
+            "**Last accuracy check:** _no record on file — this is the "
+            "page's first scheduled review._"
+        )
+    else:
+        freshness_line = (
+            f"**Last accuracy check:** `{last_check.isoformat()}` "
+            f"({age_days} days ago, threshold {max_age_days})."
+        )
+
+    parts: list[str] = []
+    parts.append(ISSUE_MARKER)
+    parts.append(f"<!-- page: {rel} -->")
+    parts.append("")
+    parts.append(f"# Accuracy review: `{rel}`")
+    parts.append("")
+    parts.append(
+        "_This issue was opened automatically by the weekly accuracy-"
+        "review workflow because this page has not been verified "
+        f"against Microsoft Learn within the last {max_age_days} days. "
+        "It is assigned to the Copilot coding agent, which will open a "
+        "draft PR. A human reviewer merges or closes._"
+    )
+    parts.append("")
+    parts.append(f"**Page title:** {safe_title}")
+    parts.append(f"**File:** `{rel}`")
+    parts.append(freshness_line)
+    parts.append("")
+    parts.append("## What to do")
+    parts.append("")
+    parts.append(
+        "Re-read this page end to end and verify every factual claim "
+        "against the **current** documentation on "
+        "[learn.microsoft.com](https://learn.microsoft.com/). Focus on:"
+    )
+    parts.append("")
+    parts.append(
+        "- Service names, SKU names, and tier names (Microsoft renames "
+        "products frequently)."
+    )
+    parts.append(
+        "- Quotas, limits, retention windows, region availability, and "
+        "any other numeric claim."
+    )
+    parts.append(
+        "- Feature availability (GA vs preview vs deprecated) and any "
+        "guidance that has been superseded."
+    )
+    parts.append(
+        "- Recommended patterns and Microsoft-prescribed best "
+        "practices that may have shifted."
+    )
+    parts.append(
+        "- External links — broken or redirected `learn.microsoft.com` "
+        "URLs should be updated to the current canonical page."
+    )
+    parts.append("")
+    parts.append("## Deliverable")
+    parts.append("")
+    parts.append(
+        "Open a **draft pull request** linked to this issue. Apply the "
+        "`accuracy-review` label to the PR — a post-merge workflow uses "
+        "that label to stamp the page's `smec:last-accuracy-check` meta "
+        "tag with the merge date."
+    )
+    parts.append("")
+    parts.append("**If corrections are needed:**")
+    parts.append("")
+    parts.append(
+        "- Edit the HTML file in place. Each substantive change must "
+        "cite a current `learn.microsoft.com` URL **in the PR "
+        "description** under a `## Sources` section, paired with the "
+        "claim it supports. Example:"
+    )
+    parts.append("")
+    parts.append("  ```")
+    parts.append("  ## Sources")
+    parts.append("  - Renamed \"Synapse Data Engineering\" to \"Fabric Data Engineering\":")
+    parts.append("    https://learn.microsoft.com/fabric/data-engineering/")
+    parts.append("  - Updated retention default from 7 to 30 days:")
+    parts.append("    https://learn.microsoft.com/azure/.../retention")
+    parts.append("  ```")
+    parts.append("")
+    parts.append(
+        "- Do not invent facts. If a claim cannot be verified against "
+        "Microsoft Learn, leave the original wording and note "
+        "`needs human verification` in the PR description rather than "
+        "guessing."
+    )
+    parts.append("")
+    parts.append("**If the page is already accurate:**")
+    parts.append("")
+    parts.append(
+        "- Open a metadata-only PR that adds (or refreshes) the "
+        "accuracy-check meta block in the page's `<head>`:"
+    )
+    parts.append("")
+    parts.append("  ```html")
+    parts.append(f"  {META_BLOCK_MARKER}")
+    parts.append(
+        f'  <meta name="{META_NAME}" content="YYYY-MM-DD">'
+    )
+    parts.append("  ```")
+    parts.append("")
+    parts.append(
+        "  Use today's UTC date as a placeholder; the post-merge "
+        "stamper will overwrite it with the actual merge date. State "
+        "in the PR description that the review found no corrections "
+        "and list the Microsoft Learn pages you cross-checked under "
+        "`## Sources`."
+    )
+    parts.append("")
+    parts.append("## Guardrails")
+    parts.append("")
+    parts.append(
+        "- The PR must modify **exactly one file**, the HTML page "
+        "named above. Do not touch any other `.html` page, any script "
+        "under `scripts/`, any workflow under `.github/`, "
+        "`manifest.json`, or `README.md`."
+    )
+    parts.append(
+        "- Do not refactor site chrome (tracking, back button, meta, "
+        "favicon) — those are owned by the `ensure-*` scripts and run "
+        "post-merge. Only the `smec-accuracy` block is in scope here."
+    )
+    parts.append(
+        "- Preserve all idempotency markers verbatim: "
+        "`data-website-id=...`, `data-smec-back-button=\"v1\"`, "
+        "`<!-- smec-meta v1 -->`, `<!-- smec-favicon v1 -->`, "
+        "`<!-- smec-tmpl:<id> -->`."
+    )
+    parts.append(
+        "- Keep the PR as a **draft** and apply the `accuracy-review` "
+        "label so the post-merge stamper picks it up."
+    )
+    parts.append("")
+    parts.append("## How to verify locally")
+    parts.append("")
+    parts.append("```bash")
+    parts.append("python3 scripts/audit-pages.py")
+    parts.append("python3 scripts/check-accuracy-staleness.py")
+    parts.append("```")
+    parts.append("")
+    body = "\n".join(parts)
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS] + "\n\n_…body truncated to fit GitHub issue size limit._\n"
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="Restrict to files whose repo-relative path starts with PREFIX.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=28,
+        help=(
+            "Pages whose recorded last-accuracy-check date is older "
+            "than this many days (default 28) are flagged. Pages "
+            "without any recorded date are always flagged."
+        ),
+    )
+    parser.add_argument(
+        "--max-issues",
+        type=int,
+        default=10,
+        help=(
+            "Cap on number of page bodies emitted per run. Throttles "
+            "the initial wave of legacy pages without markers. Pages "
+            "beyond the cap are reported on stderr and dropped."
+        ),
+    )
+    parser.add_argument(
+        "--today",
+        default=None,
+        help="Override today's date (YYYY-MM-DD); for tests.",
+    )
+    args = parser.parse_args()
+
+    if args.max_issues <= 0:
+        print("ERROR: --max-issues must be positive.", file=sys.stderr)
+        return 2
+    if args.max_age_days < 0:
+        print("ERROR: --max-age-days must be non-negative.", file=sys.stderr)
+        return 2
+
+    today = dt.date.today()
+    if args.today:
+        try:
+            today = dt.date.fromisoformat(args.today)
+        except ValueError:
+            print(f"ERROR: bad --today value {args.today!r}", file=sys.stderr)
+            return 2
+
+    only_prefix = args.only.rstrip("/") + "/" if args.only else None
+
+    eligible: list[tuple[str, str, dt.date | None, int | None]] = []
+    fresh_count = 0
+    skipped_count = 0
+
+    for filepath in sorted(iter_html_files(REPO_ROOT)):
+        rel = os.path.relpath(filepath, REPO_ROOT).replace(os.sep, "/")
+        if only_prefix and not (rel + "/").startswith(only_prefix) and rel != args.only:
+            continue
+        status, last, age = _classify(filepath, today, args.max_age_days)
+        if status == "skipped":
+            skipped_count += 1
+            continue
+        if status == "fresh":
+            fresh_count += 1
+            continue
+        # status == "stale" or "missing"
+        with open(filepath, encoding="utf-8") as fh:
+            content = fh.read()
+        title = _extract_title(
+            content, os.path.splitext(os.path.basename(filepath))[0]
+        )
+        eligible.append((rel, title, last, age))
+
+    os.makedirs(OUT_DIR, exist_ok=True)
+    # Clean previous run so the index always matches what's on disk.
+    for existing in os.listdir(OUT_DIR):
+        if existing.endswith(".md") or existing == "index.json":
+            try:
+                os.remove(os.path.join(OUT_DIR, existing))
+            except OSError:
+                pass
+
+    index: list[dict[str, Any]] = []
+    dropped_over_cap: list[str] = []
+    for rel, title, last, age in eligible:
+        if len(index) >= args.max_issues:
+            dropped_over_cap.append(rel)
+            continue
+        body = _render(rel, title, last, age, args.max_age_days)
+        slug = rel.replace("/", "__").replace(".html", "")
+        out_path = os.path.join(OUT_DIR, f"{slug}.md")
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        index.append({
+            "path": rel,
+            "title": title,
+            "body_file": os.path.basename(out_path),
+            "last_check": last.isoformat() if last else None,
+            "age_days": age,
+        })
+
+    with open(os.path.join(OUT_DIR, "index.json"), "w", encoding="utf-8") as fh:
+        json.dump({
+            "today": today.isoformat(),
+            "max_age_days": args.max_age_days,
+            "max_issues": args.max_issues,
+            "issues": index,
+            "dropped_over_cap": dropped_over_cap,
+        }, fh, indent=2)
+
+    print(f"Eligible pages: {len(eligible)}")
+    print(f"  emitted:     {len(index)}")
+    print(f"  over cap:    {len(dropped_over_cap)}")
+    print(f"Fresh pages:   {fresh_count}")
+    print(f"Skipped pages: {skipped_count}")
+    if dropped_over_cap:
+        print("Dropped (over cap):", file=sys.stderr)
+        for r in dropped_over_cap:
+            print(f"  - {r}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/stamp-accuracy-date.py
+++ b/scripts/stamp-accuracy-date.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Stamp the `smec:last-accuracy-check` meta tag on one or more HTML
+infographics with today's UTC date (or a date passed via --date).
+
+Used by the post-merge workflow `.github/workflows/accuracy-review-merge.yml`
+so that the recorded review date reflects the **merge time**, not the
+time the Copilot coding agent first opened the PR. This avoids
+shortening the next review cycle when a PR sits in review for days.
+
+Behavior per file:
+  - If the `<!-- smec-accuracy v1 -->` marker block already exists,
+    the tag's `content="..."` attribute is updated in place.
+  - Otherwise a new marker block + meta tag is injected just before
+    `</head>`.
+  - Files with no `</head>` and redirect stubs (`<meta http-equiv="refresh">`)
+    are skipped.
+
+Idempotent on the date value: re-running with the same date is a no-op
+because the regex match returns the same content.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+MARKER = "<!-- smec-accuracy v1 -->"
+META_NAME = "smec:last-accuracy-check"
+
+HEAD_CLOSE_RE = re.compile(r"^(?P<indent>[ \t]*)</head>", re.MULTILINE)
+META_REFRESH_RE = re.compile(
+    r'<meta\s+http-equiv=["\']refresh["\']', re.IGNORECASE
+)
+ACCURACY_META_RE = re.compile(
+    r'(<meta\s+[^>]*name=["\']' + re.escape(META_NAME)
+    + r'["\'][^>]*content=["\'])([^"\']*)(["\'])',
+    re.IGNORECASE,
+)
+
+
+def stamp_file(filepath: str, date_str: str) -> str:
+    """Return 'updated', 'inserted', 'unchanged', 'skipped', or 'nohead'."""
+    with open(filepath, encoding="utf-8", newline="") as fh:
+        content = fh.read()
+
+    if META_REFRESH_RE.search(content):
+        return "skipped"
+
+    m = ACCURACY_META_RE.search(content)
+    if m:
+        if m.group(2) == date_str:
+            return "unchanged"
+        new_content = (
+            content[:m.start()]
+            + m.group(1) + date_str + m.group(3)
+            + content[m.end():]
+        )
+        with open(filepath, "w", encoding="utf-8", newline="") as fh:
+            fh.write(new_content)
+        return "updated"
+
+    head_match = HEAD_CLOSE_RE.search(content)
+    if not head_match:
+        return "nohead"
+
+    nl = "\r\n" if "\r\n" in content else "\n"
+    indent = head_match.group("indent")
+    block = (
+        f"{indent}{MARKER}{nl}"
+        f'{indent}<meta name="{META_NAME}" content="{date_str}">{nl}'
+    )
+    new_content = (
+        content[:head_match.start()] + block + content[head_match.start():]
+    )
+    with open(filepath, "w", encoding="utf-8", newline="") as fh:
+        fh.write(new_content)
+    return "inserted"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help=(
+            "HTML files (repo-relative or absolute) to stamp. Non-HTML "
+            "paths are silently ignored so the workflow can pass the "
+            "raw list of changed files from a PR."
+        ),
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help=(
+            "Date to stamp (YYYY-MM-DD). Defaults to today's UTC date."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.date:
+        try:
+            date_obj = dt.date.fromisoformat(args.date)
+        except ValueError:
+            print(f"ERROR: bad --date value {args.date!r}", file=sys.stderr)
+            return 2
+    else:
+        date_obj = dt.datetime.now(dt.timezone.utc).date()
+    date_str = date_obj.isoformat()
+
+    if not args.files:
+        print("No files passed; nothing to do.")
+        return 0
+
+    totals = {
+        "updated": [], "inserted": [], "unchanged": [],
+        "skipped": [], "nohead": [], "missing": [],
+    }
+    for raw in args.files:
+        if not raw.lower().endswith(".html"):
+            continue
+        path = raw if os.path.isabs(raw) else os.path.join(REPO_ROOT, raw)
+        if not os.path.isfile(path):
+            totals["missing"].append(raw)
+            continue
+        status = stamp_file(path, date_str)
+        totals[status].append(
+            os.path.relpath(path, REPO_ROOT).replace(os.sep, "/")
+        )
+
+    print(f"Stamp date: {date_str}")
+    for status, label in (
+        ("updated", "Updated existing tag"),
+        ("inserted", "Inserted new tag"),
+        ("unchanged", "Already up to date"),
+        ("skipped", "Skipped (redirect stub)"),
+        ("nohead", "No </head> found"),
+        ("missing", "File not found"),
+    ):
+        files = totals[status]
+        print(f"{label}: {len(files)}")
+        for f in files:
+            print(f"  - {f}")
+
+    if totals["nohead"]:
+        print(
+            "ERROR: one or more HTML files have no </head> tag.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a 28-day documentation accuracy review cycle:
- scripts/check-accuracy-staleness.py scans HTML for the smec:last-accuracy-check meta tag and emits per-page issue bodies for pages missing the marker or older than 28 days.
- scripts/stamp-accuracy-date.py is an idempotent in-place stamper used by the post-merge workflow.
- .github/workflows/accuracy-review.yml runs weekly (Thursdays, staggered from the monthly copilot-page-review) and opens Copilot- assigned issues, capped at 10/run with cross-workflow dedup.
- .github/workflows/accuracy-review-merge.yml fires on merged PRs labelled accuracy-review and stamps changed HTML files with the merge date so a slow review doesn't shorten the next cycle.