### PR TITLE
Add GitHub Copilot agent infographic series

### DIFF
--- a/docs/github-copilot-agent-series-claim-matrix.md
+++ b/docs/github-copilot-agent-series-claim-matrix.md
@@ -1,0 +1,25 @@
+# GitHub Copilot Agent Series Claim Matrix
+
+Last refreshed: 2026-04-30
+
+This matrix records the accuracy pass behind the GitHub Copilot agent infographic series. It is intentionally narrow: claims are grounded in public product docs and should be rechecked before customer reuse after major Copilot, Claude, Codex, or Cursor releases.
+
+| Page / current line | Claim audited | Verdict | Replacement text now used | Primary sources |
+| --- | --- | --- | --- | --- |
+| `github-copilot/ai-coding-agent-landscape.html:181` | Agent choice framed as Copilot vs third-party vendors. | Updated | Reframed as agent control planes: GitHub-native Copilot, GitHub-hosted third-party agents, standalone vendor integrations, and Cursor Cloud Agents. Watch-outs replace "worst fit." | GitHub third-party agents, Copilot cloud agent, Cursor Cloud Agents |
+| `github-copilot/ai-agent-setup-cost.html:333` | "Only Copilot has zero repo files." | Updated | GitHub-hosted agents can be enabled without repo workflow YAML after policy enablement; standalone Claude Code Action remains the workflow-file path. | GitHub third-party agents, Claude Code GitHub Actions |
+| `github-copilot/agent-governance-surface.html:202` | Third-party options always distribute governance outside GitHub. | Updated | GitHub-hosted Claude/Codex inherit GitHub agent surfaces; standalone integrations still introduce vendor dashboards, secrets, account settings, or mixed audit surfaces. | GitHub third-party agents, OpenAI Codex GitHub integration, Cursor pricing/security notes |
+| `github-copilot/agent-commit-identity.html:206` | First-party vs third-party App is the only useful identity split. | Updated | Identity is now shown as four patterns: Copilot cloud agent, GitHub-hosted Claude/Codex, Claude Code Action, and standalone Codex/Cursor. | GitHub third-party agents, Copilot cloud agent, Claude Code GitHub Actions |
+| `github-copilot/agent-correction-loop.html:302` | Codex always pushes correction state into ChatGPT and non-Copilot loops are inherently split. | Updated | GitHub-hosted agents keep routine feedback closest to GitHub; standalone integrations can still post back to PRs but may add Actions logs, API/token cost, or vendor workspace state. | GitHub third-party agents, OpenAI Codex GitHub integration, Claude Code GitHub Actions, Cursor Cloud Agents |
+| `github-copilot/copilot-learn-mcp-dogfood.html:218` | Scheduled workflow guarantees Copilot PRs and fully automatic accuracy maintenance. | Updated | Workflow creates review issues; Copilot assignment depends on `COPILOT_ASSIGN_TOKEN` and agent availability; PR creation is intended but not guaranteed; human review remains required. | Local workflow files, Copilot cloud agent docs, Microsoft Learn MCP docs |
+
+## Source Set
+
+- GitHub Copilot cloud agent: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
+- GitHub third-party agents: https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents
+- GitHub Copilot premium requests: https://docs.github.com/en/billing/concepts/product-billing/github-copilot-premium-requests
+- OpenAI Codex GitHub integration: https://developers.openai.com/codex/integrations/github
+- Claude Code GitHub Actions: https://code.claude.com/docs/en/github-actions
+- Cursor Cloud Agents: https://cursor.com/blog/cloud-agents
+- Cursor pricing and governance signals: https://cursor.com/pricing
+- Microsoft Learn MCP: https://learn.microsoft.com/en-us/training/support/mcp

--- a/github-copilot/agent-commit-identity.html
+++ b/github-copilot/agent-commit-identity.html
@@ -106,8 +106,90 @@
   .sources-list { list-style: none; padding: 0; }
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="Who authored this PR? Agent identity on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="Who authored this PR? Agent identity on GitHub">
+<meta property="og:description" content="Who authored this PR? Agent identity on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/agent-commit-identity.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Who authored this PR? Agent identity on GitHub">
+<meta name="twitter:description" content="Who authored this PR? Agent identity on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <header class="hero">
   <div class="hero-badge">
@@ -115,15 +197,15 @@
     Governance · Commit authorship
   </div>
   <h1>Who authored this PR?</h1>
-  <p>Agent-generated PRs have an author identity. Whether that author is a first-party GitHub bot or a third-party OAuth App changes which rulesets apply, which audit logs fire, and which procurement conversations you need to have.</p>
-  <div class="hero-meta">Accurate as of April 2026 · Applies to git commit author, PR author, and ruleset evaluation</div>
+  <p>Agent-generated PRs have an author identity. The useful split is not just first-party vs third-party; it is whether the agent is GitHub-hosted or running through a standalone vendor integration.</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Applies to GitHub-hosted and GitHub-connected async agents</div>
 </header>
 
 <section>
   <div class="container">
-    <span class="section-label">Four identities</span>
+    <span class="section-label">Four identity patterns</span>
     <h2 class="section-title">What shows up in <code>git log</code></h2>
-    <p class="section-sub">Two axes matter: <strong>first-party vs. third-party</strong> (who owns the bot), and <strong>App vs. user token</strong> (how commits are signed). The combination decides which governance surfaces see the agent.</p>
+    <p class="section-sub">Two axes matter: <strong>who owns the agent</strong> and <strong>where the agent is hosted</strong>. The combination decides which rulesets, audit logs, and procurement reviews are involved.</p>
 
     <div class="identity-grid">
 
@@ -135,43 +217,43 @@
           <dt>Commit author</dt><dd><code>Copilot</code> (GitHub-native actor)</dd>
           <dt>Identity source</dt><dd>GitHub itself</dd>
           <dt>Ruleset handling</dt><dd>Dedicated Copilot bypass option</dd>
-          <dt>Procurement</dt><dd>Covered by Copilot Business/Enterprise contract</dd>
+          <dt>Procurement</dt><dd>Covered by eligible Copilot plan and GitHub terms</dd>
+        </dl>
+      </div>
+
+      <div class="id-card third">
+        <span class="tag tag-third">Third-party App</span>
+        <h3>GitHub-hosted Claude / Codex</h3>
+        <div class="handle"><span class="dot"></span>agent selected in GitHub</div>
+        <dl>
+          <dt>Commit author</dt><dd>Third-party agent actor selected through GitHub</dd>
+          <dt>Identity source</dt><dd>GitHub-hosted agent surface backed by Anthropic or OpenAI</dd>
+          <dt>Ruleset handling</dt><dd>Subject to compatible GitHub agent protections and limitations</dd>
+          <dt>Procurement</dt><dd>Copilot plan eligibility plus third-party agent policy approval</dd>
         </dl>
       </div>
 
       <div class="id-card third">
         <span class="tag tag-third">Third-party App</span>
         <h3>Claude Code Action</h3>
-        <div class="handle"><span class="dot"></span>claude[bot]</div>
+        <div class="handle"><span class="dot"></span>claude[bot] or custom App</div>
         <dl>
-          <dt>Commit author</dt><dd><code>claude[bot]</code> or custom-App name</dd>
-          <dt>Identity source</dt><dd>Anthropic GitHub App (or your custom App)</dd>
-          <dt>Ruleset handling</dt><dd>Add App as bypass actor manually</dd>
-          <dt>Procurement</dt><dd>Separate Anthropic contract; App install approval</dd>
+          <dt>Commit author</dt><dd><code>claude[bot]</code> or custom GitHub App name</dd>
+          <dt>Identity source</dt><dd>Anthropic GitHub App, or a self-owned GitHub App</dd>
+          <dt>Ruleset handling</dt><dd>Add App as bypass actor manually if required</dd>
+          <dt>Procurement</dt><dd>Separate Anthropic/API or cloud-provider approval path</dd>
         </dl>
       </div>
 
       <div class="id-card third">
         <span class="tag tag-third">Third-party App</span>
-        <h3>OpenAI Codex</h3>
-        <div class="handle"><span class="dot"></span>codex bot</div>
+        <h3>Standalone Codex / Cursor</h3>
+        <div class="handle"><span class="dot"></span>vendor integration actor</div>
         <dl>
-          <dt>Commit author</dt><dd>Codex bot identity</dd>
-          <dt>Identity source</dt><dd>OpenAI-operated service</dd>
-          <dt>Ruleset handling</dt><dd>Add as bypass actor; signs commits as Codex</dd>
-          <dt>Procurement</dt><dd>Separate OpenAI/ChatGPT contract</dd>
-        </dl>
-      </div>
-
-      <div class="id-card third">
-        <span class="tag tag-third">Third-party App</span>
-        <h3>Cursor Cloud Agents</h3>
-        <div class="handle"><span class="dot"></span>cursor bot</div>
-        <dl>
-          <dt>Commit author</dt><dd>Cursor bot identity</dd>
-          <dt>Identity source</dt><dd>Cursor-operated service with R/W scope</dd>
-          <dt>Ruleset handling</dt><dd>Add as bypass actor; needs clone + push perms</dd>
-          <dt>Procurement</dt><dd>Separate Cursor team-plan contract</dd>
+          <dt>Commit author</dt><dd>Bot or App identity from vendor GitHub connection</dd>
+          <dt>Identity source</dt><dd>ChatGPT Codex settings or Cursor cloud integration</dd>
+          <dt>Ruleset handling</dt><dd>Depends on App/OAuth permissions and branch rules</dd>
+          <dt>Procurement</dt><dd>Separate vendor account, billing, and data review</dd>
         </dl>
       </div>
 
@@ -183,43 +265,43 @@
   <div class="container">
     <span class="section-label">Consequences</span>
     <h2 class="section-title">What changes based on identity</h2>
-    <p class="section-sub">Real operational differences, not flavor text. Each row is a surface where first-party vs. third-party actually behaves differently.</p>
+    <p class="section-sub">Real operational differences, not flavor text. Each row is a surface where hosted-vs-standalone identity changes review, audit, or setup work.</p>
 
     <div class="impact-table">
       <div class="impact-row">
         <div>Surface</div>
-        <div>First-party (Copilot)</div>
-        <div>Third-party (Claude / Codex / Cursor)</div>
+        <div>GitHub-hosted agents</div>
+        <div>Standalone vendor integrations</div>
       </div>
       <div class="impact-row">
         <div class="surface">Branch protection<small>Required reviewers, restrict push</small></div>
-        <div data-label="Copilot">Dedicated bypass option in ruleset UI</div>
-        <div data-label="Third-party">Must manually add the App as bypass actor per ruleset</div>
+        <div data-label="GitHub-hosted">Rulesets and branch protections stay in GitHub; incompatible rules can still block agent work</div>
+        <div data-label="Standalone">App/OAuth actor must satisfy or bypass branch rules per integration</div>
       </div>
       <div class="impact-row">
         <div class="surface">Audit log<small>Org-level GitHub audit</small></div>
-        <div data-label="Copilot">Native events (agent run, PR created, etc.)</div>
-        <div data-label="Third-party">GitHub App action events; vendor-side logs live elsewhere</div>
+        <div data-label="GitHub-hosted">Issue, PR, review, and agent entry points stay in GitHub surfaces</div>
+        <div data-label="Standalone">GitHub records PR events; vendor dashboards or Actions logs may hold run context</div>
       </div>
       <div class="impact-row">
         <div class="surface">Commit signing<small>Verified vs. unverified</small></div>
-        <div data-label="Copilot">Signed by GitHub</div>
-        <div data-label="Third-party">Signed by App; depends on App config</div>
+        <div data-label="GitHub-hosted">Depends on the GitHub-hosted agent actor and compatible ruleset settings</div>
+        <div data-label="Standalone">Depends on vendor App, custom App, OAuth, and signing configuration</div>
       </div>
       <div class="impact-row">
         <div class="surface">SSO / SCIM scope<small>Does the agent count as a seat?</small></div>
-        <div data-label="Copilot">Within Copilot seat entitlement</div>
-        <div data-label="Third-party">Bot identity; does not consume a human SSO seat</div>
+        <div data-label="GitHub-hosted">Requires eligible Copilot plan and agent policy enablement</div>
+        <div data-label="Standalone">Requires the vendor's account, plan, API key, or workspace billing model</div>
       </div>
       <div class="impact-row">
         <div class="surface">Content exclusions<small>Copilot content-exclusion policy</small></div>
-        <div data-label="Copilot">Not honored by Copilot cloud agent (explicit limitation)</div>
-        <div data-label="Third-party">N/A; third-party agents don't read Copilot exclusion config</div>
+        <div data-label="GitHub-hosted">Copilot cloud agent does not honor Copilot content exclusions; GitHub-hosted third-party agents share those limitations</div>
+        <div data-label="Standalone">Controlled by vendor repo scope, App permissions, runner filesystem, and local instruction files</div>
       </div>
       <div class="impact-row">
         <div class="surface">Procurement review<small>Legal / InfoSec approval</small></div>
-        <div data-label="Copilot">Usually already covered</div>
-        <div data-label="Third-party">New vendor; DPIA, data residency, App permissions review</div>
+        <div data-label="GitHub-hosted">Starts with Copilot/GitHub eligibility and policy approval</div>
+        <div data-label="Standalone">Usually requires separate vendor, data, billing, and App-permission review</div>
       </div>
     </div>
 
@@ -229,9 +311,9 @@
         What this doesn't say
       </h3>
       <ul>
-        <li><strong>Third-party doesn't mean worse.</strong> A custom GitHub App gives you more permission control than a first-party bot. The cost is setup, not security.</li>
-        <li><strong>Copilot has its own gaps.</strong> The content-exclusion limitation above is a real one — Copilot cloud agent does not honor Copilot content exclusions.</li>
-        <li><strong>Custom Apps exist.</strong> Claude Code Action supports a self-owned GitHub App with your chosen name; use it if org policy blocks the vendor-owned App.</li>
+        <li><strong>Third-party doesn't mean worse.</strong> GitHub-hosted Claude/Codex can keep review workflows in GitHub, and custom Apps can give teams more control.</li>
+        <li><strong>Copilot has its own gaps.</strong> The content-exclusion limitation above is real and should be called out in sensitive repos.</li>
+        <li><strong>Identity is an audit question.</strong> Before rollout, confirm the actual bot/App actor in your organization and test it against branch rules.</li>
       </ul>
     </div>
   </div>
@@ -241,16 +323,17 @@
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>A platform-engineering view of commit-author identity for AI coding agents on GitHub. The claim is narrow: <strong>first-party bot identity reduces governance setup (rulesets, audit, procurement) but does not make an agent inherently more or less safe.</strong></p>
-      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+      <p>A platform-engineering view of commit-author identity for AI coding agents around GitHub. The claim is narrow: <strong>hosted-vs-standalone identity changes audit and setup work, but does not make an agent inherently safer or more capable.</strong></p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not an official Microsoft comparison and not endorsed by GitHub, Anthropic, OpenAI, Cursor, or Anysphere.</p>
     </div>
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent limitations</a></li>
-        <li><a href="https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md">Claude Code Action setup & custom App</a></li>
-        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
-        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents">GitHub third-party agents</a></li>
+        <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
+        <li><a href="https://developers.openai.com/codex/integrations/github">Codex GitHub integration</a></li>
+        <li><a href="https://cursor.com/blog/cloud-agents">Cursor Cloud Agents</a></li>
       </ul>
     </div>
   </div>

--- a/github-copilot/agent-commit-identity.html
+++ b/github-copilot/agent-commit-identity.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Who authored this PR? Agent identity on GitHub</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E; --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E; --gh-blue: #0969DA;
+    --gh-muted: #57606A; --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA; --gh-card: #FFFFFF;
+    --gh-ok: #1A7F37; --gh-warn: #9A6700; --gh-danger: #CF222E;
+    --radius: 10px; --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body { font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink); background: var(--gh-surface); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--gh-blue); text-decoration: none; } a:hover { text-decoration: underline; }
+  code { background: var(--gh-surface); padding: 1px 5px; border-radius: 4px; font-size: .88em; font-family: 'Cascadia Mono', 'Consolas', monospace; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .hero { background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff; padding: 80px 24px 64px; text-align: center; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%); pointer-events: none; }
+  .hero-badge { display: inline-flex; align-items: center; gap: 8px; padding: 5px 14px;
+    border-radius: 20px; background: rgba(255,255,255,.10); font-size: .78rem; font-weight: 600;
+    letter-spacing: .4px; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+    margin-bottom: 20px; border: 1px solid rgba(255,255,255,.12); }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 { font-size: clamp(1.9rem, 4.2vw, 2.8rem); font-weight: 700; line-height: 1.15;
+    max-width: 820px; margin: 0 auto 14px; }
+  .hero p { font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto; }
+  .hero-meta { margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px; }
+  section { padding: 56px 0; }
+  .section-flush-top { padding-top: 0; }
+  .section-label { display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent); margin-bottom: 8px; }
+  .section-title { font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink); }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+
+  .identity-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  @media (max-width: 720px) { .identity-grid { grid-template-columns: 1fr; } }
+  .id-card { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 22px; display: flex; flex-direction: column; gap: 12px; }
+  .id-card h3 { font-size: 1.05rem; color: var(--gh-ink); }
+  .id-card .handle { display: inline-flex; align-items: center; gap: 8px;
+    font-family: 'Cascadia Mono', Consolas, monospace; font-size: .92rem;
+    background: var(--gh-surface); padding: 8px 12px; border-radius: 6px;
+    border: 1px solid var(--gh-border); width: fit-content; }
+  .id-card .handle .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--gh-accent); }
+  .id-card.third .handle .dot { background: var(--gh-warn); }
+  .id-card dl { display: grid; grid-template-columns: 140px 1fr; gap: 6px 12px; font-size: .88rem; }
+  .id-card dt { color: var(--gh-muted); font-weight: 600; }
+  .id-card dd { color: var(--gh-ink); }
+  .tag { display: inline-flex; font-size: .7rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .04em; padding: 2px 8px; border-radius: 10px; width: fit-content; }
+  .tag-first { background: #DAFBE1; color: var(--gh-ok); }
+  .tag-third { background: #FFF8C5; color: var(--gh-warn); }
+
+  .impact-table { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+  .impact-row { display: grid; grid-template-columns: 1.4fr 1fr 1fr; border-top: 1px solid var(--gh-border); }
+  .impact-row:first-child { border-top: 0; background: var(--gh-ink); color: #fff; }
+  .impact-row:first-child > div {
+    padding: 12px 14px; font-size: .78rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+  .impact-row > div { padding: 16px 14px; font-size: .88rem;
+    border-right: 1px solid var(--gh-border); }
+  .impact-row > div:last-child { border-right: 0; }
+  .impact-row:first-child > div { border-right: 1px solid rgba(255,255,255,.08); }
+  .impact-row:first-child > div:last-child { border-right: 0; }
+  .impact-row .surface { background: var(--gh-surface); font-weight: 600; }
+  .impact-row .surface small { display: block; font-weight: 400; color: var(--gh-muted); font-size: .78rem; margin-top: 2px; }
+  @media (max-width: 720px) {
+    .impact-row { grid-template-columns: 1fr; }
+    .impact-row > div { border-right: 0; border-bottom: 1px solid var(--gh-border); }
+    .impact-row:first-child { display: none; }
+    .impact-row > div::before { content: attr(data-label); display: block;
+      font-size: .68rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
+      color: var(--gh-muted); margin-bottom: 4px; }
+    .impact-row .surface::before { display: none; }
+  }
+
+  .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-warn); border-radius: var(--radius);
+    padding: 22px; box-shadow: var(--shadow); margin-top: 24px; }
+  .callout h3 { font-size: 1.05rem; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; }
+
+  footer { background: var(--gh-ink); color: #C9D1D9; padding: 40px 24px;
+    font-size: .85rem; line-height: 1.7; }
+  footer .container { display: grid; grid-template-columns: 2fr 1fr; gap: 32px; }
+  @media (max-width: 720px) { footer .container { grid-template-columns: 1fr; } }
+  footer a { color: #58A6FF; }
+  footer h4 { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: #fff; margin-bottom: 10px; }
+  .disclosure { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E; }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    Governance · Commit authorship
+  </div>
+  <h1>Who authored this PR?</h1>
+  <p>Agent-generated PRs have an author identity. Whether that author is a first-party GitHub bot or a third-party OAuth App changes which rulesets apply, which audit logs fire, and which procurement conversations you need to have.</p>
+  <div class="hero-meta">Accurate as of April 2026 · Applies to git commit author, PR author, and ruleset evaluation</div>
+</header>
+
+<section>
+  <div class="container">
+    <span class="section-label">Four identities</span>
+    <h2 class="section-title">What shows up in <code>git log</code></h2>
+    <p class="section-sub">Two axes matter: <strong>first-party vs. third-party</strong> (who owns the bot), and <strong>App vs. user token</strong> (how commits are signed). The combination decides which governance surfaces see the agent.</p>
+
+    <div class="identity-grid">
+
+      <div class="id-card">
+        <span class="tag tag-first">First-party</span>
+        <h3>GitHub Copilot cloud agent</h3>
+        <div class="handle"><span class="dot"></span>Copilot</div>
+        <dl>
+          <dt>Commit author</dt><dd><code>Copilot</code> (GitHub-native actor)</dd>
+          <dt>Identity source</dt><dd>GitHub itself</dd>
+          <dt>Ruleset handling</dt><dd>Dedicated Copilot bypass option</dd>
+          <dt>Procurement</dt><dd>Covered by Copilot Business/Enterprise contract</dd>
+        </dl>
+      </div>
+
+      <div class="id-card third">
+        <span class="tag tag-third">Third-party App</span>
+        <h3>Claude Code Action</h3>
+        <div class="handle"><span class="dot"></span>claude[bot]</div>
+        <dl>
+          <dt>Commit author</dt><dd><code>claude[bot]</code> or custom-App name</dd>
+          <dt>Identity source</dt><dd>Anthropic GitHub App (or your custom App)</dd>
+          <dt>Ruleset handling</dt><dd>Add App as bypass actor manually</dd>
+          <dt>Procurement</dt><dd>Separate Anthropic contract; App install approval</dd>
+        </dl>
+      </div>
+
+      <div class="id-card third">
+        <span class="tag tag-third">Third-party App</span>
+        <h3>OpenAI Codex</h3>
+        <div class="handle"><span class="dot"></span>codex bot</div>
+        <dl>
+          <dt>Commit author</dt><dd>Codex bot identity</dd>
+          <dt>Identity source</dt><dd>OpenAI-operated service</dd>
+          <dt>Ruleset handling</dt><dd>Add as bypass actor; signs commits as Codex</dd>
+          <dt>Procurement</dt><dd>Separate OpenAI/ChatGPT contract</dd>
+        </dl>
+      </div>
+
+      <div class="id-card third">
+        <span class="tag tag-third">Third-party App</span>
+        <h3>Cursor Cloud Agents</h3>
+        <div class="handle"><span class="dot"></span>cursor bot</div>
+        <dl>
+          <dt>Commit author</dt><dd>Cursor bot identity</dd>
+          <dt>Identity source</dt><dd>Cursor-operated service with R/W scope</dd>
+          <dt>Ruleset handling</dt><dd>Add as bypass actor; needs clone + push perms</dd>
+          <dt>Procurement</dt><dd>Separate Cursor team-plan contract</dd>
+        </dl>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="section-flush-top">
+  <div class="container">
+    <span class="section-label">Consequences</span>
+    <h2 class="section-title">What changes based on identity</h2>
+    <p class="section-sub">Real operational differences, not flavor text. Each row is a surface where first-party vs. third-party actually behaves differently.</p>
+
+    <div class="impact-table">
+      <div class="impact-row">
+        <div>Surface</div>
+        <div>First-party (Copilot)</div>
+        <div>Third-party (Claude / Codex / Cursor)</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">Branch protection<small>Required reviewers, restrict push</small></div>
+        <div data-label="Copilot">Dedicated bypass option in ruleset UI</div>
+        <div data-label="Third-party">Must manually add the App as bypass actor per ruleset</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">Audit log<small>Org-level GitHub audit</small></div>
+        <div data-label="Copilot">Native events (agent run, PR created, etc.)</div>
+        <div data-label="Third-party">GitHub App action events; vendor-side logs live elsewhere</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">Commit signing<small>Verified vs. unverified</small></div>
+        <div data-label="Copilot">Signed by GitHub</div>
+        <div data-label="Third-party">Signed by App; depends on App config</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">SSO / SCIM scope<small>Does the agent count as a seat?</small></div>
+        <div data-label="Copilot">Within Copilot seat entitlement</div>
+        <div data-label="Third-party">Bot identity; does not consume a human SSO seat</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">Content exclusions<small>Copilot content-exclusion policy</small></div>
+        <div data-label="Copilot">Not honored by Copilot cloud agent (explicit limitation)</div>
+        <div data-label="Third-party">N/A; third-party agents don't read Copilot exclusion config</div>
+      </div>
+      <div class="impact-row">
+        <div class="surface">Procurement review<small>Legal / InfoSec approval</small></div>
+        <div data-label="Copilot">Usually already covered</div>
+        <div data-label="Third-party">New vendor; DPIA, data residency, App permissions review</div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <h3>
+        <svg viewBox="0 0 16 16" fill="#9A6700" aria-hidden="true"><path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/></svg>
+        What this doesn't say
+      </h3>
+      <ul>
+        <li><strong>Third-party doesn't mean worse.</strong> A custom GitHub App gives you more permission control than a first-party bot. The cost is setup, not security.</li>
+        <li><strong>Copilot has its own gaps.</strong> The content-exclusion limitation above is a real one — Copilot cloud agent does not honor Copilot content exclusions.</li>
+        <li><strong>Custom Apps exist.</strong> Claude Code Action supports a self-owned GitHub App with your chosen name; use it if org policy blocks the vendor-owned App.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>A platform-engineering view of commit-author identity for AI coding agents on GitHub. The claim is narrow: <strong>first-party bot identity reduces governance setup (rulesets, audit, procurement) but does not make an agent inherently more or less safe.</strong></p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent limitations</a></li>
+        <li><a href="https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md">Claude Code Action setup & custom App</a></li>
+        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
+        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/agent-correction-loop.html
+++ b/github-copilot/agent-correction-loop.html
@@ -54,8 +54,12 @@
 
   /* Signature SVG: the correction loop */
   .loop-diagram { background: var(--gh-card); border: 1px solid var(--gh-border);
-    border-radius: var(--radius); box-shadow: var(--shadow); padding: 28px 24px 20px; }
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 28px 24px 20px; overflow-x: auto; }
   .loop-diagram svg { display: block; width: 100%; height: auto; max-width: 760px; margin: 0 auto; }
+  @media (max-width: 560px) {
+    .loop-diagram { padding: 20px 16px 18px; }
+    .loop-diagram svg { min-width: 680px; }
+  }
   .loop-diagram figcaption { font-size: .82rem; color: var(--gh-muted); text-align: center; margin-top: 12px; }
   .loop-diagram .legend-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 16px; margin-top: 12px;
     font-size: .78rem; color: var(--gh-muted); }
@@ -116,8 +120,90 @@
   .sources-list { list-style: none; padding: 0; }
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="When the agent&#x27;s PR is wrong: the correction loop — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="When the agent&#x27;s PR is wrong: the correction loop">
+<meta property="og:description" content="When the agent&#x27;s PR is wrong: the correction loop — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/agent-correction-loop.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="When the agent&#x27;s PR is wrong: the correction loop">
+<meta name="twitter:description" content="When the agent&#x27;s PR is wrong: the correction loop — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <header class="hero">
   <div class="hero-badge">
@@ -125,15 +211,15 @@
     Review ergonomics · Iteration surface
   </div>
   <h1>When the agent's PR is wrong</h1>
-  <p>Every async coding agent ships broken first drafts sometimes. The question is how you tell it to try again — and whether that conversation survives in the repo or lives somewhere else.</p>
-  <div class="hero-meta">Accurate as of April 2026 · Focus: comment-driven iteration, not one-shot quality</div>
+  <p>Every async coding agent ships broken first drafts sometimes. The question is how you tell it to try again, which control plane owns the next round, and whether the review trail stays easy to reconstruct.</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Focus: comment-driven iteration, not one-shot quality</div>
 </header>
 
 <div class="container">
   <div class="big-stat">
     <div class="num">2–3</div>
     <div class="num-sub">rounds before you should take it over manually</div>
-    <div class="num-caption">Past that, iteration cost exceeds the cost of writing the fix yourself. Applies to all four agents — their loop shape just changes how much each round costs.</div>
+    <div class="num-caption">Past that, iteration cost often exceeds the cost of writing the fix yourself. Applies across hosted and standalone agents - their loop shape changes how much each round costs.</div>
   </div>
 </div>
 
@@ -141,11 +227,11 @@
   <div class="container">
     <span class="section-label">Shape of the loop</span>
     <h2 class="section-title">Four phases, same order</h2>
-    <p class="section-sub">Every async agent cycles through the same four phases. What differs is <strong>where state lives</strong> at each phase — inside the PR, or out in a vendor dashboard.</p>
+    <p class="section-sub">Every async agent cycles through the same four phases. What differs is <strong>where state lives</strong> at each phase - in GitHub issues and PRs, in Actions logs, or in a vendor workspace.</p>
 
     <figure class="loop-diagram" role="group" aria-labelledby="loop-dia-title" aria-describedby="loop-dia-desc">
       <p id="loop-dia-title" class="sr-only">The four-phase correction loop</p>
-      <p id="loop-dia-desc" class="sr-only">A circular flow with four phases in order: Comment, Run, Commit, Review, then back to Comment. Arrows between phases are color-coded. Green arrows indicate the phase state lives inside the GitHub PR (cheap, native). Amber arrows indicate state lives in a vendor dashboard (state leak). Copilot and Claude Code Action keep all four arrows green. OpenAI Codex and Cursor Cloud Agents keep Comment-to-Run green but the Run and Review phases split to a vendor surface.</p>
+      <p id="loop-dia-desc" class="sr-only">A circular flow with four phases in order: Comment, Run, Commit, Review, then back to Comment. Arrows between phases are color-coded. Green arrows indicate the phase state primarily lives in GitHub issues or PRs. Amber arrows indicate added cost or state outside the normal PR review trail, such as Actions logs, vendor API usage, or a vendor workspace. GitHub-hosted Copilot, Claude, and Codex keep routine feedback in GitHub. Standalone integrations can add workflow logs, external run state, or product dashboards.</p>
       <svg viewBox="0 0 760 360" role="img" aria-hidden="true" focusable="false">
         <defs>
           <marker id="arrow-green" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
@@ -177,15 +263,15 @@
           <text x="120" y="276" text-anchor="middle" font-size="13" font-weight="700" fill="#24292E">4 · Review</text>
           <text x="120" y="298" text-anchor="middle" font-size="11" fill="#57606A">decide next round or stop</text>
 
-          <!-- Arrow 1→2 (top, green: all four tools trigger cheaply) -->
+          <!-- Arrow 1→2 (top, green: all tools start from GitHub feedback) -->
           <line x1="215" y1="76" x2="540" y2="76" stroke="#2DA44E" stroke-width="2.5" marker-end="url(#arrow-green)"/>
-          <text x="377" y="66" text-anchor="middle" font-size="11" font-weight="600" fill="#1A7F37">native trigger</text>
-          <text x="377" y="96" text-anchor="middle" font-size="10" fill="#57606A">PR comment fires all four</text>
+          <text x="377" y="66" text-anchor="middle" font-size="11" font-weight="600" fill="#1A7F37">GitHub feedback</text>
+          <text x="377" y="96" text-anchor="middle" font-size="10" fill="#57606A">issue, assignment, or PR comment</text>
 
           <!-- Arrow 2→3 (right side, amber: run state varies) -->
           <line x1="640" y1="117" x2="640" y2="243" stroke="#9A6700" stroke-width="2.5" marker-end="url(#arrow-amber)"/>
           <text x="730" y="176" text-anchor="end" font-size="11" font-weight="600" fill="#9A6700">run cost</text>
-          <text x="730" y="192" text-anchor="end" font-size="10" fill="#57606A">Actions min. or API tokens</text>
+          <text x="730" y="192" text-anchor="end" font-size="10" fill="#57606A">premium requests, minutes, tokens</text>
 
           <!-- Arrow 3→4 (bottom, green: commit goes to PR for all) -->
           <line x1="540" y1="284" x2="215" y2="284" stroke="#2DA44E" stroke-width="2.5" marker-end="url(#arrow-green)"/>
@@ -194,21 +280,21 @@
 
           <!-- Arrow 4→1 (left side, mixed color gradient) -->
           <line x1="120" y1="243" x2="120" y2="117" stroke="#9A6700" stroke-width="2.5" stroke-dasharray="5 4" marker-end="url(#arrow-amber)"/>
-          <text x="30" y="176" text-anchor="start" font-size="11" font-weight="600" fill="#9A6700">state leak risk</text>
-          <text x="30" y="192" text-anchor="start" font-size="10" fill="#57606A">Codex / Cursor: deliberation</text>
-          <text x="30" y="206" text-anchor="start" font-size="10" fill="#57606A">in vendor dashboard</text>
+          <text x="30" y="176" text-anchor="start" font-size="11" font-weight="600" fill="#9A6700">extra state risk</text>
+          <text x="30" y="192" text-anchor="start" font-size="10" fill="#57606A">standalone integrations may</text>
+          <text x="30" y="206" text-anchor="start" font-size="10" fill="#57606A">add vendor workspace state</text>
 
           <!-- Tool footprint strip below -->
           <g transform="translate(0, 340)">
-            <text x="380" y="0" text-anchor="middle" font-size="10" fill="#57606A" font-style="italic">Solid green arrows = state in PR · dashed amber = state in vendor UI</text>
+            <text x="380" y="0" text-anchor="middle" font-size="10" fill="#57606A" font-style="italic">Solid green arrows = normal GitHub review trail · dashed amber = added cost or outside state</text>
           </g>
         </g>
       </svg>
       <div class="legend-row">
-        <span><span class="sw sw-green"></span>PR-native phase</span>
-        <span><span class="sw sw-amber"></span>Has a cost or state-leak risk</span>
+        <span><span class="sw sw-green"></span>GitHub-native phase</span>
+        <span><span class="sw sw-amber"></span>Has added cost or outside-state risk</span>
       </div>
-      <figcaption>Copilot &amp; Claude Code Action keep deliberation inside the PR across all four phases. Codex &amp; Cursor split phases 2 and 4 to their own dashboards.</figcaption>
+      <figcaption>GitHub-hosted agents keep routine feedback in GitHub. Standalone actions and vendor cloud agents can still post back to the PR, but may add Actions logs, API token usage, or vendor workspace state.</figcaption>
     </figure>
 
   </div>
@@ -218,7 +304,7 @@
   <div class="container">
     <span class="section-label">The loop</span>
     <h2 class="section-title">Four tools, four correction shapes</h2>
-    <p class="section-sub">What a reviewer has to do to get a v2. The cheaper this loop is, the more viable the "assign it to the bot" pattern becomes for real work.</p>
+    <p class="section-sub">What a reviewer has to do to get a v2. The cheaper and more inspectable this loop is, the more viable the "assign it to the agent" pattern becomes for real work.</p>
 
     <div class="loop-grid">
 
@@ -228,7 +314,17 @@
           <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment in the PR.</strong> <code>@copilot address the null-check on line 42</code>.</div></div>
           <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent wakes on the same branch.</strong> New commit pushed, same PR.</div></div>
           <div class="loop-step"><div class="n">3</div><div class="t"><strong>Review comments resolve inline.</strong> Standard GitHub review UI.</div></div>
-          <div class="loop-step"><div class="n">4</div><div class="t"><strong>Conversation stays in the PR.</strong> Every iteration is <code>git log</code>-visible.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Watch the limits.</strong> Runs can consume Actions minutes and Copilot premium requests, and content exclusions are not honored by the cloud agent.</div></div>
+        </div>
+      </div>
+
+      <div class="loop-card">
+        <header><h3>GitHub-hosted Claude / Codex</h3><div class="sub">Third-party agents in GitHub</div></header>
+        <div class="loop-steps">
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Use the GitHub agent surface.</strong> Ask from supported GitHub issues or PR workflows instead of switching to a vendor dashboard first.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>GitHub-hosted run starts.</strong> The agent works in a GitHub-managed environment and posts results back through GitHub.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Review stays where the code review lives.</strong> Follow-up feedback can stay attached to the issue or PR.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Same cloud-agent limits apply.</strong> GitHub says third-party agents share Copilot cloud agent protections and limitations.</div></div>
         </div>
       </div>
 
@@ -236,29 +332,19 @@
         <header><h3>Claude Code Action</h3><div class="sub">@claude-triggered workflow</div></header>
         <div class="loop-steps">
           <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment with <code>@claude</code>.</strong> Workflow fires on the event.</div></div>
-          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Action runs on your runner.</strong> Progress tracked in the comment itself (checkboxes that update live).</div></div>
-          <div class="loop-step"><div class="n">3</div><div class="t"><strong>New commit on the PR branch.</strong> Same PR, one Actions run per <code>@claude</code> trigger.</div></div>
-          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Each <code>@claude</code> = Actions minutes + Anthropic API tokens.</strong> Chatty reviewers cost more.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Action runs in GitHub Actions.</strong> Progress is visible through the workflow run and PR comments.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>New commit on the PR branch.</strong> Same PR, one Actions run per trigger.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Each round has runner and model cost.</strong> You manage workflow YAML, app permissions, and Anthropic credentials.</div></div>
         </div>
       </div>
 
       <div class="loop-card">
-        <header><h3>OpenAI Codex in GitHub</h3><div class="sub">@codex PR comment</div></header>
+        <header><h3>Standalone Codex / Cursor</h3><div class="sub">Vendor cloud workspace</div></header>
         <div class="loop-steps">
-          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment <code>@codex &lt;task&gt;</code>.</strong> Codex reacts with 👀.</div></div>
-          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Codex opens a cloud task.</strong> Uses the PR as context.</div></div>
-          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Updates posted back to the PR.</strong> Review step is <code>@codex review</code>, a separate command.</div></div>
-          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Full task state lives in ChatGPT Codex UI.</strong> PR sees the outputs; the deliberation is elsewhere.</div></div>
-        </div>
-      </div>
-
-      <div class="loop-card">
-        <header><h3>Cursor Cloud Agents</h3><div class="sub">@cursor PR comment (or Cursor web)</div></header>
-        <div class="loop-steps">
-          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment <code>@cursor</code> on the PR</strong> — or kick off a new run from Cursor web, Slack, Linear, or API.</div></div>
-          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent clones, modifies, pushes.</strong> Cloud VM with own tools, MCP, hooks.</div></div>
-          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Optional: follow up from the IDE.</strong> Cursor Desktop can view and continue cloud-agent runs.</div></div>
-          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Run history in Cursor dashboard.</strong> PR shows outputs; reasoning lives in Cursor's UI.</div></div>
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Start from GitHub or the vendor product.</strong> Codex and Cursor both support GitHub-connected review/task flows.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent works in a vendor-hosted environment.</strong> The product owns much of the run orchestration and task state.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Outputs come back to GitHub.</strong> Commits or review results can still land on the PR.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Reviewers may need a second surface.</strong> Detailed task history or continuation can live in ChatGPT Codex, Cursor web, Cursor Desktop, Slack, Linear, or API-driven flows.</div></div>
         </div>
       </div>
 
@@ -297,9 +383,9 @@ as the fallback and add a test for the anonymous case.
           What makes a good correction loop
         </h3>
         <ul>
-          <li><strong>One surface.</strong> Reviewers shouldn't tab between GitHub and a vendor dashboard to give feedback.</li>
-          <li><strong>Cheap iteration.</strong> The cost of a "try again" comment should not change reviewer behavior.</li>
-          <li><strong>State in the PR.</strong> Future maintainers reading <code>git log</code> + PR comments should see the whole conversation.</li>
+          <li><strong>One routine surface.</strong> Reviewers should be able to give normal correction feedback without leaving the issue or PR.</li>
+          <li><strong>Visible iteration cost.</strong> Teams should know whether a "try again" consumes Copilot premium requests, Actions minutes, vendor tokens, or subscription quota.</li>
+          <li><strong>State in the review trail.</strong> Future maintainers reading <code>git log</code> and PR comments should understand why the final patch looks the way it does.</li>
           <li><strong>Stop after 2-3 rounds.</strong> If it's still wrong, take over manually; iteration cost exceeds writing the fix.</li>
         </ul>
       </div>
@@ -312,7 +398,7 @@ as the fallback and add a test for the anonymous case.
           <li><strong>Not iteration quality.</strong> No claim about which tool's v2 is better than its v1.</li>
           <li><strong>Not response latency.</strong> All four run async; seconds-to-response varies by load, not product.</li>
           <li><strong>Not custom prompts.</strong> Each tool has fine-grained prompt-tuning features; this piece only covers the default review-driven loop.</li>
-          <li><strong>Not trigger-phrase overrides.</strong> Claude lets you rename <code>@claude</code>; Codex and Cursor likewise customize.</li>
+          <li><strong>Not trigger-phrase overrides.</strong> Agent names and triggers can vary by configuration; this piece compares the default public workflow shapes.</li>
         </ul>
       </div>
     </div>
@@ -323,15 +409,16 @@ as the fallback and add a test for the anonymous case.
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>A review-ergonomics view of AI coding agents on GitHub. The claim is narrow: <strong>Copilot and Claude keep the correction conversation inside the PR; Codex and Cursor push part of it into their own dashboards.</strong> This is a workflow-shape fact, not a capability claim.</p>
+      <p>A review-ergonomics view of AI coding agents on GitHub. The claim is narrow: <strong>GitHub-hosted agents keep routine correction feedback closest to the issue or PR; standalone vendor integrations can add valuable control, but may also add Actions logs, API credentials, subscription quota, or vendor workspace state.</strong> This is a workflow-shape fact, not a capability claim.</p>
       <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
     </div>
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
         <li><a href="https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/make-changes-to-an-existing-pr">Copilot: make changes to an existing PR</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents">GitHub third-party agents</a></li>
         <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
-        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
+        <li><a href="https://developers.openai.com/codex/integrations/github">Codex GitHub integration</a></li>
         <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
       </ul>
     </div>

--- a/github-copilot/agent-correction-loop.html
+++ b/github-copilot/agent-correction-loop.html
@@ -43,6 +43,29 @@
     margin-bottom: 10px; color: var(--gh-ink); }
   .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
 
+  /* Big-stat landing card (overlaps hero bottom) */
+  .big-stat { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow);
+    padding: 32px 28px; margin-top: -32px; position: relative; z-index: 2; text-align: center; }
+  .big-stat .num { font-size: clamp(2.4rem, 5.5vw, 3.6rem); font-weight: 800;
+    color: var(--gh-accent); line-height: 1; letter-spacing: -.02em; }
+  .big-stat .num-sub { font-size: 1rem; color: var(--gh-ink); margin-top: 8px; font-weight: 600; }
+  .big-stat .num-caption { font-size: .9rem; color: var(--gh-muted); margin-top: 4px; max-width: 620px; margin-left: auto; margin-right: auto; }
+
+  /* Signature SVG: the correction loop */
+  .loop-diagram { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 28px 24px 20px; }
+  .loop-diagram svg { display: block; width: 100%; height: auto; max-width: 760px; margin: 0 auto; }
+  .loop-diagram figcaption { font-size: .82rem; color: var(--gh-muted); text-align: center; margin-top: 12px; }
+  .loop-diagram .legend-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 16px; margin-top: 12px;
+    font-size: .78rem; color: var(--gh-muted); }
+  .loop-diagram .legend-row .sw { display: inline-block; width: 22px; height: 3px; border-radius: 2px;
+    vertical-align: middle; margin-right: 6px; }
+  .loop-diagram .legend-row .sw-green { background: var(--gh-accent); }
+  .loop-diagram .legend-row .sw-amber { background: var(--gh-warn); }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
   .loop-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
   @media (max-width: 720px) { .loop-grid { grid-template-columns: 1fr; } }
   .loop-card { background: var(--gh-card); border: 1px solid var(--gh-border);
@@ -98,7 +121,7 @@
 
 <header class="hero">
   <div class="hero-badge">
-    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.705 8.005a.75.75 0 01.834.656 5.5 5.5 0 009.592 2.97l-1.204-1.204a.25.25 0 01.177-.427h3.646a.25.25 0 01.25.25v3.646a.25.25 0 01-.427.177l-1.38-1.38A7.002 7.002 0 011.05 8.84a.75.75 0 01.656-.834zM8 2.5a5.487 5.487 0 00-4.131 1.869l1.204 1.204A.25.25 0 014.896 6H1.25A.25.25 0 011 5.75V2.104a.25.25 0 01.427-.177l1.38 1.38A7.002 7.002 0 0114.95 7.16a.75.75 0 11-1.49.178A5.5 5.5 0 008 2.5z"/></svg>
     Review ergonomics · Iteration surface
   </div>
   <h1>When the agent's PR is wrong</h1>
@@ -106,7 +129,92 @@
   <div class="hero-meta">Accurate as of April 2026 · Focus: comment-driven iteration, not one-shot quality</div>
 </header>
 
+<div class="container">
+  <div class="big-stat">
+    <div class="num">2–3</div>
+    <div class="num-sub">rounds before you should take it over manually</div>
+    <div class="num-caption">Past that, iteration cost exceeds the cost of writing the fix yourself. Applies to all four agents — their loop shape just changes how much each round costs.</div>
+  </div>
+</div>
+
 <section>
+  <div class="container">
+    <span class="section-label">Shape of the loop</span>
+    <h2 class="section-title">Four phases, same order</h2>
+    <p class="section-sub">Every async agent cycles through the same four phases. What differs is <strong>where state lives</strong> at each phase — inside the PR, or out in a vendor dashboard.</p>
+
+    <figure class="loop-diagram" role="group" aria-labelledby="loop-dia-title" aria-describedby="loop-dia-desc">
+      <p id="loop-dia-title" class="sr-only">The four-phase correction loop</p>
+      <p id="loop-dia-desc" class="sr-only">A circular flow with four phases in order: Comment, Run, Commit, Review, then back to Comment. Arrows between phases are color-coded. Green arrows indicate the phase state lives inside the GitHub PR (cheap, native). Amber arrows indicate state lives in a vendor dashboard (state leak). Copilot and Claude Code Action keep all four arrows green. OpenAI Codex and Cursor Cloud Agents keep Comment-to-Run green but the Run and Review phases split to a vendor surface.</p>
+      <svg viewBox="0 0 760 360" role="img" aria-hidden="true" focusable="false">
+        <defs>
+          <marker id="arrow-green" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="#2DA44E"/>
+          </marker>
+          <marker id="arrow-amber" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="#9A6700"/>
+          </marker>
+        </defs>
+        <!-- Nodes: 4 rounded rects at corners of a rectangle -->
+        <g font-family="'Segoe UI', system-ui, sans-serif">
+          <!-- Node 1: Comment (top-left) -->
+          <rect x="30" y="40" width="180" height="72" rx="10" fill="#F6F8FA" stroke="#D0D7DE"/>
+          <text x="120" y="68" text-anchor="middle" font-size="13" font-weight="700" fill="#24292E">1 · Comment</text>
+          <text x="120" y="90" text-anchor="middle" font-size="11" fill="#57606A">@copilot / @claude / @codex / @cursor</text>
+
+          <!-- Node 2: Run (top-right) -->
+          <rect x="550" y="40" width="180" height="72" rx="10" fill="#F6F8FA" stroke="#D0D7DE"/>
+          <text x="640" y="68" text-anchor="middle" font-size="13" font-weight="700" fill="#24292E">2 · Run</text>
+          <text x="640" y="90" text-anchor="middle" font-size="11" fill="#57606A">ephemeral env, tools, LLM</text>
+
+          <!-- Node 3: Commit (bottom-right) -->
+          <rect x="550" y="248" width="180" height="72" rx="10" fill="#F6F8FA" stroke="#D0D7DE"/>
+          <text x="640" y="276" text-anchor="middle" font-size="13" font-weight="700" fill="#24292E">3 · Commit</text>
+          <text x="640" y="298" text-anchor="middle" font-size="11" fill="#57606A">push to the PR branch</text>
+
+          <!-- Node 4: Review (bottom-left) -->
+          <rect x="30" y="248" width="180" height="72" rx="10" fill="#F6F8FA" stroke="#D0D7DE"/>
+          <text x="120" y="276" text-anchor="middle" font-size="13" font-weight="700" fill="#24292E">4 · Review</text>
+          <text x="120" y="298" text-anchor="middle" font-size="11" fill="#57606A">decide next round or stop</text>
+
+          <!-- Arrow 1→2 (top, green: all four tools trigger cheaply) -->
+          <line x1="215" y1="76" x2="540" y2="76" stroke="#2DA44E" stroke-width="2.5" marker-end="url(#arrow-green)"/>
+          <text x="377" y="66" text-anchor="middle" font-size="11" font-weight="600" fill="#1A7F37">native trigger</text>
+          <text x="377" y="96" text-anchor="middle" font-size="10" fill="#57606A">PR comment fires all four</text>
+
+          <!-- Arrow 2→3 (right side, amber: run state varies) -->
+          <line x1="640" y1="117" x2="640" y2="243" stroke="#9A6700" stroke-width="2.5" marker-end="url(#arrow-amber)"/>
+          <text x="730" y="176" text-anchor="end" font-size="11" font-weight="600" fill="#9A6700">run cost</text>
+          <text x="730" y="192" text-anchor="end" font-size="10" fill="#57606A">Actions min. or API tokens</text>
+
+          <!-- Arrow 3→4 (bottom, green: commit goes to PR for all) -->
+          <line x1="540" y1="284" x2="215" y2="284" stroke="#2DA44E" stroke-width="2.5" marker-end="url(#arrow-green)"/>
+          <text x="377" y="274" text-anchor="middle" font-size="11" font-weight="600" fill="#1A7F37">PR branch</text>
+          <text x="377" y="304" text-anchor="middle" font-size="10" fill="#57606A">commit pushed, same PR</text>
+
+          <!-- Arrow 4→1 (left side, mixed color gradient) -->
+          <line x1="120" y1="243" x2="120" y2="117" stroke="#9A6700" stroke-width="2.5" stroke-dasharray="5 4" marker-end="url(#arrow-amber)"/>
+          <text x="30" y="176" text-anchor="start" font-size="11" font-weight="600" fill="#9A6700">state leak risk</text>
+          <text x="30" y="192" text-anchor="start" font-size="10" fill="#57606A">Codex / Cursor: deliberation</text>
+          <text x="30" y="206" text-anchor="start" font-size="10" fill="#57606A">in vendor dashboard</text>
+
+          <!-- Tool footprint strip below -->
+          <g transform="translate(0, 340)">
+            <text x="380" y="0" text-anchor="middle" font-size="10" fill="#57606A" font-style="italic">Solid green arrows = state in PR · dashed amber = state in vendor UI</text>
+          </g>
+        </g>
+      </svg>
+      <div class="legend-row">
+        <span><span class="sw sw-green"></span>PR-native phase</span>
+        <span><span class="sw sw-amber"></span>Has a cost or state-leak risk</span>
+      </div>
+      <figcaption>Copilot &amp; Claude Code Action keep deliberation inside the PR across all four phases. Codex &amp; Cursor split phases 2 and 4 to their own dashboards.</figcaption>
+    </figure>
+
+  </div>
+</section>
+
+<section class="section-flush-top">
   <div class="container">
     <span class="section-label">The loop</span>
     <h2 class="section-title">Four tools, four correction shapes</h2>

--- a/github-copilot/agent-correction-loop.html
+++ b/github-copilot/agent-correction-loop.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>When the agent's PR is wrong: the correction loop</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E; --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E; --gh-blue: #0969DA;
+    --gh-muted: #57606A; --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA; --gh-card: #FFFFFF;
+    --gh-ok: #1A7F37; --gh-warn: #9A6700; --gh-danger: #CF222E;
+    --radius: 10px; --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body { font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink); background: var(--gh-surface); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--gh-blue); text-decoration: none; } a:hover { text-decoration: underline; }
+  code { background: var(--gh-surface); padding: 1px 5px; border-radius: 4px; font-size: .88em; font-family: 'Cascadia Mono', Consolas, monospace; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .hero { background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff; padding: 80px 24px 64px; text-align: center; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%); pointer-events: none; }
+  .hero-badge { display: inline-flex; align-items: center; gap: 8px; padding: 5px 14px;
+    border-radius: 20px; background: rgba(255,255,255,.10); font-size: .78rem; font-weight: 600;
+    letter-spacing: .4px; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+    margin-bottom: 20px; border: 1px solid rgba(255,255,255,.12); }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 { font-size: clamp(1.9rem, 4.2vw, 2.8rem); font-weight: 700; line-height: 1.15;
+    max-width: 820px; margin: 0 auto 14px; }
+  .hero p { font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto; }
+  .hero-meta { margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px; }
+  section { padding: 56px 0; }
+  .section-flush-top { padding-top: 0; }
+  .section-label { display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent); margin-bottom: 8px; }
+  .section-title { font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink); }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+
+  .loop-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  @media (max-width: 720px) { .loop-grid { grid-template-columns: 1fr; } }
+  .loop-card { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+  .loop-card header { background: var(--gh-ink); color: #fff; padding: 14px 18px; }
+  .loop-card header h3 { font-size: 1rem; font-weight: 700; }
+  .loop-card header .sub { font-size: .74rem; opacity: .7; margin-top: 2px; }
+  .loop-steps { padding: 18px 20px; display: flex; flex-direction: column; gap: 12px; }
+  .loop-step { display: grid; grid-template-columns: 28px 1fr; gap: 10px; align-items: start; }
+  .loop-step .n { width: 24px; height: 24px; border-radius: 50%; background: var(--gh-accent);
+    color: #fff; font-size: .78rem; font-weight: 700; display: inline-flex;
+    align-items: center; justify-content: center; margin-top: 1px; }
+  .loop-step .t { font-size: .88rem; color: var(--gh-ink); }
+  .loop-step .t strong { color: var(--gh-ink-2); }
+  .loop-step.pain .n { background: var(--gh-danger); }
+  .loop-step.pain .t { color: var(--gh-muted); }
+
+  .prompt-box { background: var(--gh-ink); color: #E6EDF3; border-radius: var(--radius);
+    padding: 16px 18px; font-family: 'Cascadia Mono', Consolas, monospace; font-size: .82rem;
+    line-height: 1.5; margin: 10px 0 0; box-shadow: var(--shadow); }
+  .prompt-box code { background: transparent; color: #F0F6FC; padding: 0; }
+  .prompt-box .at { color: #79C0FF; }
+  .pb-label { display: block; font-size: .76rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .06em; color: var(--gh-muted); margin-bottom: 4px; }
+  .pb-label.good { color: var(--gh-accent); }
+
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  .two-col-gap { margin-top: 32px; }
+  @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
+
+  .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-accent); border-radius: var(--radius);
+    padding: 22px; box-shadow: var(--shadow); }
+  .callout.caveat { border-left-color: var(--gh-warn); }
+  .callout h3 { font-size: 1.05rem; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; }
+
+  footer { background: var(--gh-ink); color: #C9D1D9; padding: 40px 24px;
+    font-size: .85rem; line-height: 1.7; }
+  footer .container { display: grid; grid-template-columns: 2fr 1fr; gap: 32px; }
+  @media (max-width: 720px) { footer .container { grid-template-columns: 1fr; } }
+  footer a { color: #58A6FF; }
+  footer h4 { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: #fff; margin-bottom: 10px; }
+  .disclosure { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E; }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    Review ergonomics · Iteration surface
+  </div>
+  <h1>When the agent's PR is wrong</h1>
+  <p>Every async coding agent ships broken first drafts sometimes. The question is how you tell it to try again — and whether that conversation survives in the repo or lives somewhere else.</p>
+  <div class="hero-meta">Accurate as of April 2026 · Focus: comment-driven iteration, not one-shot quality</div>
+</header>
+
+<section>
+  <div class="container">
+    <span class="section-label">The loop</span>
+    <h2 class="section-title">Four tools, four correction shapes</h2>
+    <p class="section-sub">What a reviewer has to do to get a v2. The cheaper this loop is, the more viable the "assign it to the bot" pattern becomes for real work.</p>
+
+    <div class="loop-grid">
+
+      <div class="loop-card">
+        <header><h3>GitHub Copilot cloud agent</h3><div class="sub">Native PR surface</div></header>
+        <div class="loop-steps">
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment in the PR.</strong> <code>@copilot address the null-check on line 42</code>.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent wakes on the same branch.</strong> New commit pushed, same PR.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Review comments resolve inline.</strong> Standard GitHub review UI.</div></div>
+          <div class="loop-step"><div class="n">4</div><div class="t"><strong>Conversation stays in the PR.</strong> Every iteration is <code>git log</code>-visible.</div></div>
+        </div>
+      </div>
+
+      <div class="loop-card">
+        <header><h3>Claude Code Action</h3><div class="sub">@claude-triggered workflow</div></header>
+        <div class="loop-steps">
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment with <code>@claude</code>.</strong> Workflow fires on the event.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Action runs on your runner.</strong> Progress tracked in the comment itself (checkboxes).</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>New commit on the PR branch.</strong> Same PR, one Actions run per iteration.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Each <code>@claude</code> = Actions minutes + API tokens.</strong> Chatty reviewers cost more.</div></div>
+        </div>
+      </div>
+
+      <div class="loop-card">
+        <header><h3>OpenAI Codex in GitHub</h3><div class="sub">@codex PR comment</div></header>
+        <div class="loop-steps">
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment <code>@codex &lt;task&gt;</code>.</strong> Codex reacts with 👀.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Codex opens a cloud task.</strong> Uses the PR as context.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Updates posted back to the PR.</strong> Review step is <code>@codex review</code>, a separate command.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Full task state lives in ChatGPT Codex UI.</strong> PR sees the outputs; the deliberation is elsewhere.</div></div>
+        </div>
+      </div>
+
+      <div class="loop-card">
+        <header><h3>Cursor Cloud Agents</h3><div class="sub">@cursor PR comment (or Cursor web)</div></header>
+        <div class="loop-steps">
+          <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment <code>@cursor</code> on the PR</strong> — or kick off a new run from Cursor web, Slack, Linear, or API.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent clones, modifies, pushes.</strong> Cloud VM with own tools, MCP, hooks.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Optional: hand off to IDE.</strong> Same agent context available in Cursor Desktop.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Run history in Cursor dashboard.</strong> PR shows outputs; reasoning lives in Cursor's UI.</div></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section class="section-flush-top">
+  <div class="container">
+    <span class="section-label">Practical pattern</span>
+    <h2 class="section-title">What a good correction comment looks like</h2>
+    <p class="section-sub">All four respond better to concrete, diff-specific feedback than to "this is wrong, try again." Pattern below works on any of them.</p>
+
+    <div class="two-col">
+      <div>
+        <span class="pb-label">Weak</span>
+        <div class="prompt-box">
+<span class="at">@copilot</span> this doesn't work, please fix it
+        </div>
+      </div>
+      <div>
+        <span class="pb-label good">Better</span>
+        <div class="prompt-box">
+<span class="at">@copilot</span> the rate-limit check in <code>auth.ts:42</code>
+uses <code>user.id</code> as the key but that's null
+for unauthenticated requests. Use <code>request.ip</code>
+as the fallback and add a test for the anonymous case.
+        </div>
+      </div>
+    </div>
+
+    <div class="two-col two-col-gap">
+      <div class="callout">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#2DA44E" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+          What makes a good correction loop
+        </h3>
+        <ul>
+          <li><strong>One surface.</strong> Reviewers shouldn't tab between GitHub and a vendor dashboard to give feedback.</li>
+          <li><strong>Cheap iteration.</strong> The cost of a "try again" comment should not change reviewer behavior.</li>
+          <li><strong>State in the PR.</strong> Future maintainers reading <code>git log</code> + PR comments should see the whole conversation.</li>
+          <li><strong>Stop after 2-3 rounds.</strong> If it's still wrong, take over manually; iteration cost exceeds writing the fix.</li>
+        </ul>
+      </div>
+      <div class="callout caveat">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#9A6700" aria-hidden="true"><path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/></svg>
+          What this piece doesn't compare
+        </h3>
+        <ul>
+          <li><strong>Not iteration quality.</strong> No claim about which tool's v2 is better than its v1.</li>
+          <li><strong>Not response latency.</strong> All four run async; seconds-to-response varies by load, not product.</li>
+          <li><strong>Not custom prompts.</strong> Each tool has fine-grained prompt-tuning features; this piece only covers the default review-driven loop.</li>
+          <li><strong>Not trigger-phrase overrides.</strong> Claude lets you rename <code>@claude</code>; Codex and Cursor likewise customize.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>A review-ergonomics view of AI coding agents on GitHub. The claim is narrow: <strong>Copilot and Claude keep the correction conversation inside the PR; Codex and Cursor push part of it into their own dashboards.</strong> This is a workflow-shape fact, not a capability claim.</p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/make-changes-to-an-existing-pr">Copilot: make changes to an existing PR</a></li>
+        <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
+        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
+        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/agent-correction-loop.html
+++ b/github-copilot/agent-correction-loop.html
@@ -128,9 +128,9 @@
         <header><h3>Claude Code Action</h3><div class="sub">@claude-triggered workflow</div></header>
         <div class="loop-steps">
           <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment with <code>@claude</code>.</strong> Workflow fires on the event.</div></div>
-          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Action runs on your runner.</strong> Progress tracked in the comment itself (checkboxes).</div></div>
-          <div class="loop-step"><div class="n">3</div><div class="t"><strong>New commit on the PR branch.</strong> Same PR, one Actions run per iteration.</div></div>
-          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Each <code>@claude</code> = Actions minutes + API tokens.</strong> Chatty reviewers cost more.</div></div>
+          <div class="loop-step"><div class="n">2</div><div class="t"><strong>Action runs on your runner.</strong> Progress tracked in the comment itself (checkboxes that update live).</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>New commit on the PR branch.</strong> Same PR, one Actions run per <code>@claude</code> trigger.</div></div>
+          <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Each <code>@claude</code> = Actions minutes + Anthropic API tokens.</strong> Chatty reviewers cost more.</div></div>
         </div>
       </div>
 
@@ -149,7 +149,7 @@
         <div class="loop-steps">
           <div class="loop-step"><div class="n">1</div><div class="t"><strong>Comment <code>@cursor</code> on the PR</strong> — or kick off a new run from Cursor web, Slack, Linear, or API.</div></div>
           <div class="loop-step"><div class="n">2</div><div class="t"><strong>Agent clones, modifies, pushes.</strong> Cloud VM with own tools, MCP, hooks.</div></div>
-          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Optional: hand off to IDE.</strong> Same agent context available in Cursor Desktop.</div></div>
+          <div class="loop-step"><div class="n">3</div><div class="t"><strong>Optional: follow up from the IDE.</strong> Cursor Desktop can view and continue cloud-agent runs.</div></div>
           <div class="loop-step pain"><div class="n">!</div><div class="t"><strong>Run history in Cursor dashboard.</strong> PR shows outputs; reasoning lives in Cursor's UI.</div></div>
         </div>
       </div>

--- a/github-copilot/agent-governance-surface.html
+++ b/github-copilot/agent-governance-surface.html
@@ -102,8 +102,90 @@
   .sources-list { list-style: none; padding: 0; }
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="Where does the agent&#x27;s audit trail live? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="Where does the agent&#x27;s audit trail live?">
+<meta property="og:description" content="Where does the agent&#x27;s audit trail live? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/agent-governance-surface.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Where does the agent&#x27;s audit trail live?">
+<meta name="twitter:description" content="Where does the agent&#x27;s audit trail live? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <header class="hero">
   <div class="hero-badge">
@@ -111,70 +193,70 @@
     Governance · Audit surface
   </div>
   <h1>Where does the agent's audit trail live?</h1>
-  <p>Six governance surfaces — policy, audit log, secrets, rulesets, metrics, content exclusions. For each, which product owns the source of truth? GitHub, the vendor, or a mix?</p>
-  <div class="hero-meta">Accurate as of April 2026 · Surfaces an InfoSec reviewer will ask about</div>
+  <p>Six governance surfaces — policy, audit log, secrets, rulesets, metrics, content exclusions. For each, which control plane owns the source of truth?</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Surfaces an InfoSec reviewer will ask about</div>
 </header>
 
 <section>
   <div class="container">
-    <span class="section-label">Six surfaces, four tools</span>
+    <span class="section-label">Six surfaces, four control planes</span>
     <h2 class="section-title">Who owns the source of truth</h2>
-    <p class="section-sub">This isn't about whether governance exists — all four tools have it. It's about where you have to look, and how many places a regulator or auditor has to query to reconstruct what happened.</p>
+    <p class="section-sub">This isn't about whether governance exists. It's about where you have to look, and how many places a regulator or auditor has to query to reconstruct what happened.</p>
 
     <div class="gov">
       <div class="gov-row">
         <div>Surface</div>
-        <div>GitHub Copilot</div>
-        <div>Claude Code Action</div>
-        <div>OpenAI Codex</div>
+        <div>Copilot cloud agent</div>
+        <div>GitHub-hosted Claude/Codex</div>
+        <div>Standalone Claude/Codex</div>
         <div>Cursor Cloud Agents</div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Enablement policy<small>Who can turn it on</small></div>
-        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot admin policies; org opt-out of agent per repo.</span></div>
-        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">App install in GitHub; API key in Anthropic console.</span></div>
-        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Per-repo toggle in ChatGPT Codex settings.</span></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot plan eligibility, account/org policy, repo opt-out.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-gh">GitHub</span><span class="cell-note">Third-party agent policy inside GitHub/Copilot; public preview.</span></div>
+        <div data-label="Standalone"><span class="loc loc-mix">Mixed</span><span class="cell-note">Claude App/workflow or ChatGPT Codex per-repo settings.</span></div>
         <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Cursor team dashboard; per-repo connect.</span></div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Audit log<small>Who did what, when</small></div>
-        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">GitHub audit log + Copilot metrics API.</span></div>
-        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub Actions run log + Anthropic console usage.</span></div>
-        <div data-label="Codex"><span class="loc loc-mix">Mixed</span><span class="cell-note">PR events in GitHub; task history in ChatGPT.</span></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">GitHub agent activity plus Copilot usage and PR metrics.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-gh">GitHub</span><span class="cell-note">Agent starts, PRs, and review comments stay in GitHub surfaces.</span></div>
+        <div data-label="Standalone"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub PR events plus Actions logs, Anthropic usage, or ChatGPT Codex settings/history.</span></div>
         <div data-label="Cursor"><span class="loc loc-mix">Mixed</span><span class="cell-note">PR events in GitHub; agent runs in Cursor dashboard.</span></div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Secrets management<small>API keys, tokens</small></div>
-        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">No user-supplied secret required.</span></div>
-        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note"><code>ANTHROPIC_API_KEY</code> as GitHub Actions secret.</span></div>
-        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Codex holds credentials; GitHub connection via OAuth.</span></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">No repo API key needed for default use.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-gh">GitHub</span><span class="cell-note">No repo workflow secret for the GitHub-hosted agent path.</span></div>
+        <div data-label="Standalone"><span class="loc loc-mix">Mixed</span><span class="cell-note">Claude Action uses GitHub secrets; standalone Codex uses ChatGPT/GitHub connection settings.</span></div>
         <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Cursor holds credentials; repo R/W via OAuth.</span></div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Rulesets & branch protection<small>Who can bypass</small></div>
         <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Native Copilot bypass actor option.</span></div>
-        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
-        <div data-label="Codex"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-gh">GitHub</span><span class="cell-note">Same compatible-ruleset constraint as Copilot cloud agent.</span></div>
+        <div data-label="Standalone"><span class="loc loc-gh">GitHub</span><span class="cell-note">Depends on GitHub App/OAuth identity and ruleset bypass configuration.</span></div>
         <div data-label="Cursor"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Usage metrics<small>PRs created, merge rate</small></div>
-        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot usage metrics API; PR-outcome breakdowns.</span></div>
-        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub Insights + Anthropic billing/usage.</span></div>
-        <div data-label="Codex"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub + ChatGPT Codex usage views.</span></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot usage metrics and PR-outcome reporting.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-gh">GitHub</span><span class="cell-note">GitHub/Copilot premium request and agent session reporting.</span></div>
+        <div data-label="Standalone"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub plus Anthropic/API, Actions, or ChatGPT Codex usage views.</span></div>
         <div data-label="Cursor"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub + Cursor dashboard usage views.</span></div>
       </div>
 
       <div class="gov-row">
         <div class="surface">Content exclusions<small>Files the agent can't read</small></div>
         <div data-label="Copilot"><span class="loc loc-vendor">Not honored</span><span class="cell-note">Copilot cloud agent does <strong>not</strong> honor Copilot content exclusions.</span></div>
-        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note">Controlled by App permissions + runner filesystem.</span></div>
-        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Governed by Codex's repo scope + <code>AGENTS.md</code>.</span></div>
+        <div data-label="GitHub-hosted"><span class="loc loc-vendor">Not honored</span><span class="cell-note">GitHub docs say third-party agents share Copilot cloud agent's protections and limitations.</span></div>
+        <div data-label="Standalone"><span class="loc loc-mix">Mixed</span><span class="cell-note">Depends on App permissions, runner filesystem, repo scope, and vendor config.</span></div>
         <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Governed by Cursor's GitHub integration scope.</span></div>
       </div>
     </div>
@@ -182,7 +264,7 @@
     <div class="legend">
       <span class="loc loc-gh">GitHub</span> Source of truth in GitHub
       <span class="loc loc-mix">Mixed</span> Split between GitHub and vendor
-      <span class="loc loc-vendor">Vendor</span> Source of truth in vendor's dashboard
+      <span class="loc loc-vendor">Vendor</span> Source of truth is outside GitHub or limitation is not governed by GitHub content exclusion
     </div>
 
     <div class="two-col">
@@ -192,9 +274,9 @@
           When single-surface governance matters
         </h3>
         <ul>
-          <li><strong>Regulated industries.</strong> Auditors prefer one log to subpoena, not five.</li>
-          <li><strong>Incident response.</strong> One query to reconstruct "what did the agent touch?" beats four.</li>
-          <li><strong>Access revocation.</strong> Disabling a first-party bot is one toggle; off-boarding four vendors is four tickets.</li>
+          <li><strong>Regulated industries.</strong> Fewer control planes usually means fewer logs and policies to reconcile.</li>
+          <li><strong>Incident response.</strong> GitHub-hosted agents keep issue, PR, and review state close to the code.</li>
+          <li><strong>Access revocation.</strong> GitHub policy controls are simpler to audit than multiple disconnected vendor setups.</li>
         </ul>
       </div>
       <div class="callout caveat">
@@ -203,10 +285,10 @@
           Where this story gets complicated
         </h3>
         <ul>
-          <li><strong>Copilot's content-exclusion gap is real.</strong> The one place Copilot's governance is <em>worse</em> than the alternatives today.</li>
-          <li><strong>Claude Code Action runs on your runner.</strong> This means code never leaves your GitHub control plane — the cleanest third-party story.</li>
-          <li><strong>"Mixed" isn't inherently bad.</strong> Vendor-side usage views often have better product-specific analytics than GitHub's generic ones.</li>
-          <li><strong>All four tools change governance surfaces quarterly.</strong> Re-check this table every 90 days.</li>
+          <li><strong>Content exclusion is the key caveat.</strong> Copilot cloud agent does not honor Copilot content exclusions, and GitHub-hosted third-party agents share those limitations.</li>
+          <li><strong>Claude Code Action can be attractive for runner control.</strong> The tradeoff is workflow and secret management per repo.</li>
+          <li><strong>"Mixed" is not automatically bad.</strong> Vendor-side usage views may be valuable; they just add another evidence surface.</li>
+          <li><strong>Agent governance changes quickly.</strong> Re-check this table before reusing it after major product updates.</li>
         </ul>
       </div>
     </div>
@@ -217,16 +299,18 @@
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>An InfoSec / platform-governance view of AI coding agents on GitHub. The claim is narrow: <strong>Copilot concentrates governance surfaces inside GitHub; the third-party options distribute them across at least two products.</strong> Each pattern has tradeoffs.</p>
-      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+      <p>An InfoSec / platform-governance view of AI coding agents around GitHub. The claim is narrow: <strong>GitHub-hosted agents concentrate the review workflow in GitHub; standalone vendor paths add useful controls but also additional evidence surfaces.</strong> Each pattern has tradeoffs.</p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not an official Microsoft comparison and not endorsed by GitHub, Anthropic, OpenAI, Cursor, or Anysphere.</p>
     </div>
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent (incl. content-exclusion limitation)</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents">GitHub third-party agents</a></li>
         <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
-        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
-        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+        <li><a href="https://developers.openai.com/codex/integrations/github">Codex GitHub integration</a></li>
+        <li><a href="https://cursor.com/blog/cloud-agents">Cursor Cloud Agents</a></li>
+        <li><a href="https://cursor.com/pricing">Cursor pricing and plans</a></li>
       </ul>
     </div>
   </div>

--- a/github-copilot/agent-governance-surface.html
+++ b/github-copilot/agent-governance-surface.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Where does the agent's audit trail live?</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E; --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E; --gh-blue: #0969DA;
+    --gh-muted: #57606A; --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA; --gh-card: #FFFFFF;
+    --gh-ok: #1A7F37; --gh-warn: #9A6700; --gh-danger: #CF222E;
+    --radius: 10px; --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body { font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink); background: var(--gh-surface); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--gh-blue); text-decoration: none; } a:hover { text-decoration: underline; }
+  code { background: var(--gh-surface); padding: 1px 5px; border-radius: 4px; font-size: .88em; font-family: 'Cascadia Mono', Consolas, monospace; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .hero { background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff; padding: 80px 24px 64px; text-align: center; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%); pointer-events: none; }
+  .hero-badge { display: inline-flex; align-items: center; gap: 8px; padding: 5px 14px;
+    border-radius: 20px; background: rgba(255,255,255,.10); font-size: .78rem; font-weight: 600;
+    letter-spacing: .4px; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+    margin-bottom: 20px; border: 1px solid rgba(255,255,255,.12); }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 { font-size: clamp(1.9rem, 4.2vw, 2.8rem); font-weight: 700; line-height: 1.15;
+    max-width: 820px; margin: 0 auto 14px; }
+  .hero p { font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto; }
+  .hero-meta { margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px; }
+  section { padding: 56px 0; }
+  .section-flush-top { padding-top: 0; }
+  .section-label { display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent); margin-bottom: 8px; }
+  .section-title { font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink); }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+
+  .gov { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+  .gov-row { display: grid; grid-template-columns: 1.4fr repeat(4, 1fr); border-top: 1px solid var(--gh-border); }
+  .gov-row:first-child { border-top: 0; background: var(--gh-ink); color: #fff; }
+  .gov-row:first-child > div { padding: 12px 12px; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .04em; border-right: 1px solid rgba(255,255,255,.08); }
+  .gov-row:first-child > div:last-child { border-right: 0; }
+  .gov-row > div { padding: 14px 12px; font-size: .84rem; border-right: 1px solid var(--gh-border);
+    display: flex; flex-direction: column; gap: 4px; min-height: 82px; }
+  .gov-row > div:last-child { border-right: 0; }
+  .gov-row .surface { background: var(--gh-surface); font-weight: 600; }
+  .gov-row .surface small { font-weight: 400; color: var(--gh-muted); font-size: .76rem; }
+  .loc { display: inline-flex; font-size: .68rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .04em; padding: 2px 7px; border-radius: 10px; width: fit-content; }
+  .loc-gh { background: #DAFBE1; color: var(--gh-ok); }
+  .loc-mix { background: #FFF8C5; color: var(--gh-warn); }
+  .loc-vendor { background: #FFEBE9; color: var(--gh-danger); }
+  .cell-note { color: var(--gh-muted); font-size: .8rem; line-height: 1.45; }
+
+  @media (max-width: 820px) {
+    .gov-row:first-child { display: none; }
+    .gov-row { grid-template-columns: 1fr; border-top: 8px solid var(--gh-surface); }
+    .gov-row > div { border-right: 0; border-bottom: 1px solid var(--gh-border); min-height: 0; }
+    .gov-row > div:last-child { border-bottom: 0; }
+    .gov-row .surface { background: var(--gh-ink); color: #fff; }
+    .gov-row .surface small { color: rgba(255,255,255,.7); }
+    .gov-row > div:not(.surface)::before {
+      content: attr(data-label); display: block; font-size: .68rem;
+      font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
+      color: var(--gh-muted); margin-bottom: 4px;
+    }
+  }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 10px; margin: 16px 0 0;
+    font-size: .78rem; color: var(--gh-muted); }
+  .legend .loc { font-size: .68rem; }
+
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 30px; }
+  @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
+  .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-accent); border-radius: var(--radius);
+    padding: 22px; box-shadow: var(--shadow); }
+  .callout.caveat { border-left-color: var(--gh-warn); }
+  .callout h3 { font-size: 1.05rem; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; }
+
+  footer { background: var(--gh-ink); color: #C9D1D9; padding: 40px 24px;
+    font-size: .85rem; line-height: 1.7; }
+  footer .container { display: grid; grid-template-columns: 2fr 1fr; gap: 32px; }
+  @media (max-width: 720px) { footer .container { grid-template-columns: 1fr; } }
+  footer a { color: #58A6FF; }
+  footer h4 { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: #fff; margin-bottom: 10px; }
+  .disclosure { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E; }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    Governance · Audit surface
+  </div>
+  <h1>Where does the agent's audit trail live?</h1>
+  <p>Six governance surfaces — policy, audit log, secrets, rulesets, metrics, content exclusions. For each, which product owns the source of truth? GitHub, the vendor, or a mix?</p>
+  <div class="hero-meta">Accurate as of April 2026 · Surfaces an InfoSec reviewer will ask about</div>
+</header>
+
+<section>
+  <div class="container">
+    <span class="section-label">Six surfaces, four tools</span>
+    <h2 class="section-title">Who owns the source of truth</h2>
+    <p class="section-sub">This isn't about whether governance exists — all four tools have it. It's about where you have to look, and how many places a regulator or auditor has to query to reconstruct what happened.</p>
+
+    <div class="gov">
+      <div class="gov-row">
+        <div>Surface</div>
+        <div>GitHub Copilot</div>
+        <div>Claude Code Action</div>
+        <div>OpenAI Codex</div>
+        <div>Cursor Cloud Agents</div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Enablement policy<small>Who can turn it on</small></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot admin policies; org opt-out of agent per repo.</span></div>
+        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">App install in GitHub; API key in Anthropic console.</span></div>
+        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Per-repo toggle in ChatGPT Codex settings.</span></div>
+        <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Cursor team dashboard; per-repo connect.</span></div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Audit log<small>Who did what, when</small></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">GitHub audit log + Copilot metrics API.</span></div>
+        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub Actions run log + Anthropic console usage.</span></div>
+        <div data-label="Codex"><span class="loc loc-mix">Mixed</span><span class="cell-note">PR events in GitHub; task history in ChatGPT.</span></div>
+        <div data-label="Cursor"><span class="loc loc-mix">Mixed</span><span class="cell-note">PR events in GitHub; agent runs in Cursor dashboard.</span></div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Secrets management<small>API keys, tokens</small></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">No user-supplied secret required.</span></div>
+        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note"><code>ANTHROPIC_API_KEY</code> as GitHub Actions secret.</span></div>
+        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Codex holds credentials; GitHub connection via OAuth.</span></div>
+        <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Cursor holds credentials; repo R/W via OAuth.</span></div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Rulesets & branch protection<small>Who can bypass</small></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Native Copilot bypass actor option.</span></div>
+        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
+        <div data-label="Codex"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
+        <div data-label="Cursor"><span class="loc loc-gh">GitHub</span><span class="cell-note">Add App as bypass actor manually.</span></div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Usage metrics<small>PRs created, merge rate</small></div>
+        <div data-label="Copilot"><span class="loc loc-gh">GitHub</span><span class="cell-note">Copilot usage metrics API; PR-outcome breakdowns.</span></div>
+        <div data-label="Claude"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub Insights + Anthropic billing/usage.</span></div>
+        <div data-label="Codex"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub + ChatGPT Codex usage views.</span></div>
+        <div data-label="Cursor"><span class="loc loc-mix">Mixed</span><span class="cell-note">GitHub + Cursor dashboard usage views.</span></div>
+      </div>
+
+      <div class="gov-row">
+        <div class="surface">Content exclusions<small>Files the agent can't read</small></div>
+        <div data-label="Copilot"><span class="loc loc-vendor">Not honored</span><span class="cell-note">Copilot cloud agent does <strong>not</strong> honor Copilot content exclusions.</span></div>
+        <div data-label="Claude"><span class="loc loc-gh">GitHub</span><span class="cell-note">Controlled by App permissions + runner filesystem.</span></div>
+        <div data-label="Codex"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Governed by Codex's repo scope + <code>AGENTS.md</code>.</span></div>
+        <div data-label="Cursor"><span class="loc loc-vendor">Vendor</span><span class="cell-note">Governed by Cursor's GitHub integration scope.</span></div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <span class="loc loc-gh">GitHub</span> Source of truth in GitHub
+      <span class="loc loc-mix">Mixed</span> Split between GitHub and vendor
+      <span class="loc loc-vendor">Vendor</span> Source of truth in vendor's dashboard
+    </div>
+
+    <div class="two-col">
+      <div class="callout">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#2DA44E" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+          When single-surface governance matters
+        </h3>
+        <ul>
+          <li><strong>Regulated industries.</strong> Auditors prefer one log to subpoena, not five.</li>
+          <li><strong>Incident response.</strong> One query to reconstruct "what did the agent touch?" beats four.</li>
+          <li><strong>Access revocation.</strong> Disabling a first-party bot is one toggle; off-boarding four vendors is four tickets.</li>
+        </ul>
+      </div>
+      <div class="callout caveat">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#9A6700" aria-hidden="true"><path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/></svg>
+          Where this story gets complicated
+        </h3>
+        <ul>
+          <li><strong>Copilot's content-exclusion gap is real.</strong> The one place Copilot's governance is <em>worse</em> than the alternatives today.</li>
+          <li><strong>Claude Code Action runs on your runner.</strong> This means code never leaves your GitHub control plane — the cleanest third-party story.</li>
+          <li><strong>"Mixed" isn't inherently bad.</strong> Vendor-side usage views often have better product-specific analytics than GitHub's generic ones.</li>
+          <li><strong>All four tools change governance surfaces quarterly.</strong> Re-check this table every 90 days.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>An InfoSec / platform-governance view of AI coding agents on GitHub. The claim is narrow: <strong>Copilot concentrates governance surfaces inside GitHub; the third-party options distribute them across at least two products.</strong> Each pattern has tradeoffs.</p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent (incl. content-exclusion limitation)</a></li>
+        <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
+        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
+        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/ai-agent-setup-cost.html
+++ b/github-copilot/ai-agent-setup-cost.html
@@ -227,8 +227,90 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
   .section-flush-top { padding-top: 0; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="Setup cost to first PR: AI coding agents on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="Setup cost to first PR: AI coding agents on GitHub">
+<meta property="og:description" content="Setup cost to first PR: AI coding agents on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/ai-agent-setup-cost.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Setup cost to first PR: AI coding agents on GitHub">
+<meta name="twitter:description" content="Setup cost to first PR: AI coding agents on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <!-- ── Hero ───────────────────────────────────────── -->
 <header class="hero">
@@ -239,16 +321,16 @@
     Platform engineering · GitHub Copilot series
   </div>
   <h1>Setup cost to first PR</h1>
-  <p>Four AI coding agents trigger from a GitHub issue or PR. Getting them <em>there</em> costs wildly different amounts of per-repo, per-org work.</p>
-  <div class="hero-meta">Accurate as of April 2026 · Applies to GitHub.com public and private repos</div>
+  <p>Async coding agents can all end in a pull request. The setup cost changes based on control plane: GitHub-native, GitHub-hosted third-party, standalone vendor workflow, or Cursor cloud.</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Applies to GitHub.com-hosted repos and GitHub-connected agents</div>
 </header>
 
 <div class="container">
   <!-- ── Big stat ─────────────────────────────── -->
   <div class="big-stat">
     <div class="num">0</div>
-    <div class="num-sub">repo-level files, secrets, or workflows required</div>
-    <div class="num-caption">for GitHub Copilot cloud agent — the only option in this set where that's true. The other three all ship something into your repo or your CI.</div>
+    <div class="num-sub">repo-level workflow files required</div>
+    <div class="num-caption">for Copilot cloud agent or GitHub-hosted Claude/Codex after policy enablement. Standalone Claude Code Action is the notable workflow-file path.</div>
   </div>
 </div>
 
@@ -256,33 +338,33 @@
 <section>
   <div class="container">
     <span class="section-label">The comparison</span>
-    <h2 class="section-title">Five dimensions, four tools</h2>
-    <p class="section-sub">Setup cost, not raw capability. A capable agent that takes a week of org plumbing to enable is a different product than a weaker one you turn on from a dropdown.</p>
+    <h2 class="section-title">Five dimensions, four setup paths</h2>
+    <p class="section-sub">Setup cost, not raw capability. The same model family can feel very different depending on whether it runs through GitHub, a GitHub Actions workflow, or a vendor dashboard.</p>
 
     <div class="matrix" role="table" aria-label="AI coding agent setup comparison">
 
       <div class="matrix-header" role="row">
         <div role="columnheader">Dimension</div>
-        <div role="columnheader"><div class="tool-logo">GitHub Copilot</div></div>
-        <div role="columnheader"><div class="tool-logo">Claude Code Action</div></div>
-        <div role="columnheader"><div class="tool-logo">OpenAI Codex</div></div>
+        <div role="columnheader"><div class="tool-logo">Copilot cloud agent</div></div>
+        <div role="columnheader"><div class="tool-logo">GitHub-hosted Claude/Codex</div></div>
+        <div role="columnheader"><div class="tool-logo">Standalone Claude/Codex</div></div>
         <div role="columnheader"><div class="tool-logo">Cursor Cloud Agents</div></div>
       </div>
 
       <!-- Row 1: Trigger surface -->
       <div class="matrix-row" role="row">
         <div class="dim" role="cell">Trigger surface<br><small>How a human starts it</small></div>
-        <div role="cell" data-label="GitHub Copilot">
+        <div role="cell" data-label="Copilot cloud agent">
           <span class="cell-tag tag-none">Native</span>
           <span class="cell-note">Assign issue to <strong>Copilot</strong>, <code>@copilot</code> in a comment, agents panel, or IDE.</span>
         </div>
-        <div role="cell" data-label="Claude Code">
-          <span class="cell-tag tag-none">Native-ish</span>
-          <span class="cell-note"><code>@claude</code> mention in issue/PR comment (needs workflow in repo).</span>
+        <div role="cell" data-label="GitHub-hosted Claude/Codex">
+          <span class="cell-tag tag-none">Native</span>
+          <span class="cell-note">Agents tab, issue assignment, PR comment mention, GitHub Mobile, or VS Code delegation.</span>
         </div>
-        <div role="cell" data-label="Codex">
-          <span class="cell-tag tag-none">Native-ish</span>
-          <span class="cell-note"><code>@codex review</code> or <code>@codex &lt;task&gt;</code> in PR comment.</span>
+        <div role="cell" data-label="Standalone Claude/Codex">
+          <span class="cell-tag tag-light">Vendor path</span>
+          <span class="cell-note"><code>@claude</code> through Actions, or <code>@codex review</code> / <code>@codex &lt;task&gt;</code> through ChatGPT Codex settings.</span>
         </div>
         <div role="cell" data-label="Cursor">
           <span class="cell-tag tag-none">Native-ish</span>
@@ -293,17 +375,17 @@
       <!-- Row 2: Org prereq -->
       <div class="matrix-row" role="row">
         <div class="dim" role="cell">Org-level prereq<br><small>What an admin sets up once</small></div>
-        <div role="cell" data-label="GitHub Copilot">
+        <div role="cell" data-label="Copilot cloud agent">
           <span class="cell-tag tag-light">Policy</span>
-          <span class="cell-note">Copilot Business/Enterprise policy enable. Already in most GitHub customers.</span>
+          <span class="cell-note">Copilot plan eligibility plus account/org/enterprise policy enablement.</span>
         </div>
-        <div role="cell" data-label="Claude Code">
-          <span class="cell-tag tag-heavy">App install</span>
-          <span class="cell-note">Install Anthropic's Claude GitHub App (or build custom App). Requires org/repo admin.</span>
+        <div role="cell" data-label="GitHub-hosted Claude/Codex">
+          <span class="cell-tag tag-light">Policy</span>
+          <span class="cell-note">Copilot Pro, Pro+, Business, or Enterprise eligibility; third-party agents are public preview and must be enabled.</span>
         </div>
-        <div role="cell" data-label="Codex">
-          <span class="cell-tag tag-heavy">External SaaS</span>
-          <span class="cell-note">Codex cloud account, GitHub connection, per-repo toggle inside ChatGPT settings.</span>
+        <div role="cell" data-label="Standalone Claude/Codex">
+          <span class="cell-tag tag-heavy">Vendor setup</span>
+          <span class="cell-note">Claude GitHub App + secret/workflow, or Codex cloud account + GitHub connection + per-repo review toggle.</span>
         </div>
         <div role="cell" data-label="Cursor">
           <span class="cell-tag tag-heavy">External SaaS</span>
@@ -314,17 +396,17 @@
       <!-- Row 3: Per-repo files -->
       <div class="matrix-row" role="row">
         <div class="dim" role="cell">Per-repo files<br><small>Committed into the repo</small></div>
-        <div role="cell" data-label="GitHub Copilot">
+        <div role="cell" data-label="Copilot cloud agent">
           <span class="cell-tag tag-none">None required</span>
           <span class="cell-note">Optional <code>copilot-instructions.md</code>, MCP config, or custom agents — but zero required.</span>
         </div>
-        <div role="cell" data-label="Claude Code">
-          <span class="cell-tag tag-heavy">Workflow YAML</span>
-          <span class="cell-note"><code>.github/workflows/claude.yml</code> + <code>ANTHROPIC_API_KEY</code> secret per repo.</span>
+        <div role="cell" data-label="GitHub-hosted Claude/Codex">
+          <span class="cell-tag tag-none">None required</span>
+          <span class="cell-note">No workflow YAML required for GitHub-hosted third-party agents; repo instructions remain optional.</span>
         </div>
-        <div role="cell" data-label="Codex">
-          <span class="cell-tag tag-light">Optional</span>
-          <span class="cell-note">No workflow needed. Optional <code>AGENTS.md</code> for review guidelines.</span>
+        <div role="cell" data-label="Standalone Claude/Codex">
+          <span class="cell-tag tag-heavy">Mixed</span>
+          <span class="cell-note">Claude Action needs workflow YAML + secret. Standalone Codex review needs no workflow; <code>AGENTS.md</code> is optional guidance.</span>
         </div>
         <div role="cell" data-label="Cursor">
           <span class="cell-tag tag-light">Optional</span>
@@ -335,17 +417,17 @@
       <!-- Row 4: Author identity -->
       <div class="matrix-row" role="row">
         <div class="dim" role="cell">Commit / PR author<br><small>Who shows up in <code>git log</code></small></div>
-        <div role="cell" data-label="GitHub Copilot">
+        <div role="cell" data-label="Copilot cloud agent">
           <span class="cell-tag tag-none">First-party bot</span>
           <span class="cell-note">Authored by <code>Copilot</code>. Inherits Copilot-specific ruleset bypass options.</span>
         </div>
-        <div role="cell" data-label="Claude Code">
+        <div role="cell" data-label="GitHub-hosted Claude/Codex">
           <span class="cell-tag tag-light">Third-party App</span>
-          <span class="cell-note"><code>claude[bot]</code> or custom-App-name. Must be added as ruleset bypass actor.</span>
+          <span class="cell-note">Third-party agent selected inside GitHub; rulesets and compatible protections still apply.</span>
         </div>
-        <div role="cell" data-label="Codex">
+        <div role="cell" data-label="Standalone Claude/Codex">
           <span class="cell-tag tag-light">Third-party App</span>
-          <span class="cell-note">Codex bot identity; external service signs the commits.</span>
+          <span class="cell-note">Bot/App identity depends on vendor integration and configured GitHub App/OAuth permissions.</span>
         </div>
         <div role="cell" data-label="Cursor">
           <span class="cell-tag tag-light">Third-party App</span>
@@ -356,17 +438,17 @@
       <!-- Row 5: Templatable -->
       <div class="matrix-row" role="row">
         <div class="dim" role="cell">Templatable across N repos<br><small>If you have 50</small></div>
-        <div role="cell" data-label="GitHub Copilot">
+        <div role="cell" data-label="Copilot cloud agent">
           <span class="cell-tag tag-none">Policy-driven</span>
           <span class="cell-note">Enable once at org level; repo owners can opt out. No per-repo fan-out.</span>
         </div>
-        <div role="cell" data-label="Claude Code">
-          <span class="cell-tag tag-heavy">Fan-out</span>
-          <span class="cell-note">Workflow file + secret must land in every repo. Org-wide secret helps; file does not.</span>
+        <div role="cell" data-label="GitHub-hosted Claude/Codex">
+          <span class="cell-tag tag-none">Policy-driven</span>
+          <span class="cell-note">Enable supported third-party agents through GitHub/Copilot policy; no repo workflow fan-out.</span>
         </div>
-        <div role="cell" data-label="Codex">
-          <span class="cell-tag tag-light">Per-repo toggle</span>
-          <span class="cell-note">Toggle each repo inside ChatGPT Codex settings. Governance lives outside GitHub.</span>
+        <div role="cell" data-label="Standalone Claude/Codex">
+          <span class="cell-tag tag-light">Path-dependent</span>
+          <span class="cell-note">Claude Action fans out workflow files; standalone Codex uses ChatGPT Codex per-repo settings.</span>
         </div>
         <div role="cell" data-label="Cursor">
           <span class="cell-tag tag-light">Per-repo connect</span>
@@ -388,13 +470,13 @@
           <svg viewBox="0 0 16 16" fill="var(--gh-accent)" aria-hidden="true">
             <path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/>
           </svg>
-          When Copilot's setup advantage decides it
+          When GitHub-hosted setup wins
         </h3>
         <ul>
           <li><strong>You have many repos.</strong> Fleet-wide enablement beats per-repo plumbing.</li>
-          <li><strong>Security reviews the agent's identity.</strong> First-party GitHub bot needs less paperwork than three external OAuth apps with R/W scopes.</li>
-          <li><strong>You already pay for Copilot.</strong> No new vendor, new invoice, or new data-processing agreement.</li>
-          <li><strong>Governance lives in GitHub.</strong> Rulesets, branch protections, and audit log cover the agent by default.</li>
+          <li><strong>Security reviews the agent surface.</strong> GitHub-hosted agents keep more of the workflow in existing GitHub controls.</li>
+          <li><strong>You already have Copilot eligibility.</strong> Copilot and supported third-party agents can start from the same GitHub agent entry points.</li>
+          <li><strong>Governance starts in GitHub.</strong> Rulesets, branch protections, policies, and review comments remain central.</li>
         </ul>
       </div>
 
@@ -408,8 +490,8 @@
         <ul>
           <li><strong>Capability ≠ setup cost.</strong> This card says nothing about which agent writes better code or resolves harder issues.</li>
           <li><strong>One repo, no fleet.</strong> The per-repo workflow tax is a coffee break, not a program of work.</li>
-          <li><strong>You want a specific model.</strong> If you need Claude Opus, GPT-5, or Cursor's model pool against your repo, you need that vendor's path.</li>
-          <li><strong>Ruleset compatibility.</strong> Copilot itself can be blocked by branch-protection rules until added as a bypass actor — not zero-friction, just low-friction.</li>
+          <li><strong>You need a vendor-specific workflow.</strong> Claude Code Action, ChatGPT Codex, and Cursor all expose product-specific controls outside the GitHub-hosted agent path.</li>
+          <li><strong>Ruleset compatibility.</strong> GitHub-hosted agents can still be blocked by incompatible rules until configured correctly.</li>
         </ul>
       </div>
 
@@ -422,16 +504,18 @@
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>A setup-cost comparison for platform leads evaluating AI coding agents on GitHub. The claim being made is narrow: <strong>GitHub Copilot has meaningfully less per-repo and per-org onboarding work than the other three</strong> because GitHub owns the surface. Every other question — code quality, model choice, cost at scale, trust — is intentionally out of scope.</p>
-      <p class="disclosure">Produced by a Microsoft employee. Views are my own; this is not an official Microsoft comparison and is not endorsed by GitHub, Anthropic, OpenAI, or Cursor. Published under the SME&amp;C Infographics library.</p>
+      <p>A setup-cost comparison for platform leads evaluating AI coding agents around GitHub. The claim is narrow: <strong>GitHub-hosted agents reduce per-repo onboarding; standalone vendor paths trade that for vendor-specific controls and workflows.</strong> Code quality, model quality, and procurement fit are intentionally out of scope.</p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; this is not an official Microsoft comparison and is not endorsed by GitHub, Anthropic, OpenAI, Cursor, or Anysphere. Published under the SME&amp;C Infographics library.</p>
     </div>
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent — GitHub Docs</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents">GitHub third-party agents</a></li>
         <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
-        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub — OpenAI</a></li>
-        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+        <li><a href="https://developers.openai.com/codex/integrations/github">Codex GitHub integration — OpenAI</a></li>
+        <li><a href="https://cursor.com/blog/cloud-agents">Cursor Cloud Agents</a></li>
+        <li><a href="https://cursor.com/pricing">Cursor pricing and plans</a></li>
       </ul>
     </div>
   </div>

--- a/github-copilot/ai-agent-setup-cost.html
+++ b/github-copilot/ai-agent-setup-cost.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Setup cost to first PR: AI coding agents on GitHub</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E;
+    --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E;   /* GitHub green */
+    --gh-blue: #0969DA;
+    --gh-muted: #57606A;
+    --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA;
+    --gh-card: #FFFFFF;
+    --gh-ok: #1A7F37;
+    --gh-warn: #9A6700;
+    --gh-danger: #CF222E;
+    --radius: 10px;
+    --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body {
+    font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink);
+    background: var(--gh-surface);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--gh-blue); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+  /* ── Hero ─────────────────────────────── */
+  .hero {
+    background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff;
+    padding: 80px 24px 64px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+  }
+  .hero::before {
+    content: '';
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%);
+    pointer-events: none;
+  }
+  .hero-badge {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 5px 14px; border-radius: 20px;
+    background: rgba(255,255,255,.10);
+    font-size: .78rem; font-weight: 600; letter-spacing: .4px;
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+    margin-bottom: 20px;
+    border: 1px solid rgba(255,255,255,.12);
+  }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 {
+    font-size: clamp(1.9rem, 4.2vw, 2.8rem);
+    font-weight: 700; line-height: 1.15; max-width: 820px;
+    margin: 0 auto 14px;
+  }
+  .hero p {
+    font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto;
+  }
+  .hero-meta {
+    margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px;
+  }
+
+  /* ── Section shell ─────────────────────── */
+  section { padding: 56px 0; }
+  .section-label {
+    display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent);
+    margin-bottom: 8px;
+  }
+  .section-title {
+    font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink);
+  }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+
+  /* ── Big stat ─────────────────────────── */
+  .big-stat {
+    background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow);
+    padding: 36px 28px; margin-top: -32px; position: relative; z-index: 2;
+    text-align: center;
+  }
+  .big-stat .num {
+    font-size: clamp(2.4rem, 5.5vw, 3.6rem); font-weight: 800;
+    color: var(--gh-accent); line-height: 1; letter-spacing: -.02em;
+  }
+  .big-stat .num-sub {
+    font-size: 1rem; color: var(--gh-ink); margin-top: 8px; font-weight: 600;
+  }
+  .big-stat .num-caption {
+    font-size: .9rem; color: var(--gh-muted); margin-top: 4px;
+  }
+
+  /* ── Comparison grid ───────────────────── */
+  .matrix {
+    background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow);
+    overflow: hidden;
+  }
+  .matrix-header,
+  .matrix-row {
+    display: grid;
+    grid-template-columns: 1.6fr 1fr 1fr 1fr 1fr;
+    gap: 0;
+  }
+  .matrix-header {
+    background: var(--gh-ink); color: #fff;
+  }
+  .matrix-header > div {
+    padding: 14px 14px; font-size: .78rem; font-weight: 700;
+    letter-spacing: .04em; text-transform: uppercase;
+    border-right: 1px solid rgba(255,255,255,.08);
+  }
+  .matrix-header > div:last-child { border-right: 0; }
+  .matrix-header .tool-logo {
+    display: flex; align-items: center; gap: 6px;
+    font-size: .78rem;
+  }
+  .matrix-row {
+    border-top: 1px solid var(--gh-border);
+  }
+  .matrix-row > div {
+    padding: 16px 14px; font-size: .88rem;
+    border-right: 1px solid var(--gh-border);
+    display: flex; flex-direction: column; gap: 4px;
+    min-height: 84px;
+  }
+  .matrix-row > div:last-child { border-right: 0; }
+  .matrix-row .dim {
+    background: var(--gh-surface); font-weight: 600; color: var(--gh-ink);
+    justify-content: center;
+  }
+  .matrix-row .dim small {
+    font-weight: 400; color: var(--gh-muted); font-size: .78rem;
+  }
+  .cell-tag {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: .72rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .04em; padding: 2px 8px; border-radius: 10px;
+    width: fit-content;
+  }
+  .tag-none { background: #DAFBE1; color: var(--gh-ok); }
+  .tag-light { background: #FFF8C5; color: var(--gh-warn); }
+  .tag-heavy { background: #FFEBE9; color: var(--gh-danger); }
+  .cell-note { color: var(--gh-muted); font-size: .82rem; line-height: 1.45; }
+
+  @media (max-width: 820px) {
+    .matrix-header { display: none; }
+    .matrix-row {
+      grid-template-columns: 1fr; border-top: 8px solid var(--gh-surface);
+    }
+    .matrix-row > div {
+      border-right: 0; border-bottom: 1px solid var(--gh-border);
+      min-height: 0;
+    }
+    .matrix-row > div:last-child { border-bottom: 0; }
+    .matrix-row .dim {
+      background: var(--gh-ink); color: #fff; padding: 10px 14px;
+      justify-content: flex-start;
+    }
+    .matrix-row .dim small { color: rgba(255,255,255,.7); }
+    .matrix-row > div:not(.dim)::before {
+      content: attr(data-label);
+      display: block; font-size: .68rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: .06em;
+      color: var(--gh-muted); margin-bottom: 4px;
+    }
+  }
+
+  /* ── Takeaway / caveats ───────────────── */
+  .two-col {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 20px;
+  }
+  @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
+  .callout {
+    background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-accent);
+    border-radius: var(--radius); padding: 22px 22px; box-shadow: var(--shadow);
+  }
+  .callout.caveat { border-left-color: var(--gh-warn); }
+  .callout h3 {
+    font-size: 1.05rem; margin-bottom: 10px; color: var(--gh-ink);
+    display: flex; align-items: center; gap: 8px;
+  }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; color: var(--gh-ink); }
+  .callout li:last-child { margin-bottom: 0; }
+  .callout li strong { color: var(--gh-ink-2); }
+
+  /* ── Footer ───────────────────────────── */
+  footer {
+    background: var(--gh-ink); color: #C9D1D9;
+    padding: 40px 24px; font-size: .85rem; line-height: 1.7;
+  }
+  footer .container {
+    display: grid; grid-template-columns: 2fr 1fr; gap: 32px;
+  }
+  @media (max-width: 720px) {
+    footer .container { grid-template-columns: 1fr; }
+  }
+  footer a { color: #58A6FF; }
+  footer h4 {
+    font-size: .78rem; text-transform: uppercase; letter-spacing: .08em;
+    color: #fff; margin-bottom: 10px;
+  }
+  .disclosure {
+    margin-top: 16px; padding-top: 14px;
+    border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E;
+  }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+  .section-flush-top { padding-top: 0; }
+</style>
+</head>
+<body>
+
+<!-- ── Hero ───────────────────────────────────────── -->
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+    </svg>
+    Platform engineering · GitHub Copilot series
+  </div>
+  <h1>Setup cost to first PR</h1>
+  <p>Four AI coding agents trigger from a GitHub issue or PR. Getting them <em>there</em> costs wildly different amounts of per-repo, per-org work.</p>
+  <div class="hero-meta">Accurate as of April 2026 · Applies to GitHub.com public and private repos</div>
+</header>
+
+<div class="container">
+  <!-- ── Big stat ─────────────────────────────── -->
+  <div class="big-stat">
+    <div class="num">0</div>
+    <div class="num-sub">repo-level files, secrets, or workflows required</div>
+    <div class="num-caption">for GitHub Copilot cloud agent — the only option in this set where that's true. The other three all ship something into your repo or your CI.</div>
+  </div>
+</div>
+
+<!-- ── Matrix ────────────────────────────────── -->
+<section>
+  <div class="container">
+    <span class="section-label">The comparison</span>
+    <h2 class="section-title">Five dimensions, four tools</h2>
+    <p class="section-sub">Setup cost, not raw capability. A capable agent that takes a week of org plumbing to enable is a different product than a weaker one you turn on from a dropdown.</p>
+
+    <div class="matrix" role="table" aria-label="AI coding agent setup comparison">
+
+      <div class="matrix-header" role="row">
+        <div role="columnheader">Dimension</div>
+        <div role="columnheader"><div class="tool-logo">GitHub Copilot</div></div>
+        <div role="columnheader"><div class="tool-logo">Claude Code Action</div></div>
+        <div role="columnheader"><div class="tool-logo">OpenAI Codex</div></div>
+        <div role="columnheader"><div class="tool-logo">Cursor Cloud Agents</div></div>
+      </div>
+
+      <!-- Row 1: Trigger surface -->
+      <div class="matrix-row" role="row">
+        <div class="dim" role="cell">Trigger surface<br><small>How a human starts it</small></div>
+        <div role="cell" data-label="GitHub Copilot">
+          <span class="cell-tag tag-none">Native</span>
+          <span class="cell-note">Assign issue to <strong>Copilot</strong>, <code>@copilot</code> in a comment, agents panel, or IDE.</span>
+        </div>
+        <div role="cell" data-label="Claude Code">
+          <span class="cell-tag tag-none">Native-ish</span>
+          <span class="cell-note"><code>@claude</code> mention in issue/PR comment (needs workflow in repo).</span>
+        </div>
+        <div role="cell" data-label="Codex">
+          <span class="cell-tag tag-none">Native-ish</span>
+          <span class="cell-note"><code>@codex review</code> or <code>@codex &lt;task&gt;</code> in PR comment.</span>
+        </div>
+        <div role="cell" data-label="Cursor">
+          <span class="cell-tag tag-none">Native-ish</span>
+          <span class="cell-note"><code>@cursor</code> PR/issue comment, plus Cursor web, Slack, Linear, API.</span>
+        </div>
+      </div>
+
+      <!-- Row 2: Org prereq -->
+      <div class="matrix-row" role="row">
+        <div class="dim" role="cell">Org-level prereq<br><small>What an admin sets up once</small></div>
+        <div role="cell" data-label="GitHub Copilot">
+          <span class="cell-tag tag-light">Policy</span>
+          <span class="cell-note">Copilot Business/Enterprise policy enable. Already in most GitHub customers.</span>
+        </div>
+        <div role="cell" data-label="Claude Code">
+          <span class="cell-tag tag-heavy">App install</span>
+          <span class="cell-note">Install Anthropic's Claude GitHub App (or build custom App). Requires org/repo admin.</span>
+        </div>
+        <div role="cell" data-label="Codex">
+          <span class="cell-tag tag-heavy">External SaaS</span>
+          <span class="cell-note">Codex cloud account, GitHub connection, per-repo toggle inside ChatGPT settings.</span>
+        </div>
+        <div role="cell" data-label="Cursor">
+          <span class="cell-tag tag-heavy">External SaaS</span>
+          <span class="cell-note">Cursor team plan, GitHub connection with read-write, spend limit set.</span>
+        </div>
+      </div>
+
+      <!-- Row 3: Per-repo files -->
+      <div class="matrix-row" role="row">
+        <div class="dim" role="cell">Per-repo files<br><small>Committed into the repo</small></div>
+        <div role="cell" data-label="GitHub Copilot">
+          <span class="cell-tag tag-none">None required</span>
+          <span class="cell-note">Optional <code>copilot-instructions.md</code>, MCP config, or custom agents — but zero required.</span>
+        </div>
+        <div role="cell" data-label="Claude Code">
+          <span class="cell-tag tag-heavy">Workflow YAML</span>
+          <span class="cell-note"><code>.github/workflows/claude.yml</code> + <code>ANTHROPIC_API_KEY</code> secret per repo.</span>
+        </div>
+        <div role="cell" data-label="Codex">
+          <span class="cell-tag tag-light">Optional</span>
+          <span class="cell-note">No workflow needed. Optional <code>AGENTS.md</code> for review guidelines.</span>
+        </div>
+        <div role="cell" data-label="Cursor">
+          <span class="cell-tag tag-light">Optional</span>
+          <span class="cell-note">No workflow needed. Optional <code>.cursor/hooks.json</code>, <code>AGENTS.md</code>.</span>
+        </div>
+      </div>
+
+      <!-- Row 4: Author identity -->
+      <div class="matrix-row" role="row">
+        <div class="dim" role="cell">Commit / PR author<br><small>Who shows up in <code>git log</code></small></div>
+        <div role="cell" data-label="GitHub Copilot">
+          <span class="cell-tag tag-none">First-party bot</span>
+          <span class="cell-note">Authored by <code>Copilot</code>. Inherits Copilot-specific ruleset bypass options.</span>
+        </div>
+        <div role="cell" data-label="Claude Code">
+          <span class="cell-tag tag-light">Third-party App</span>
+          <span class="cell-note"><code>claude[bot]</code> or custom-App-name. Must be added as ruleset bypass actor.</span>
+        </div>
+        <div role="cell" data-label="Codex">
+          <span class="cell-tag tag-light">Third-party App</span>
+          <span class="cell-note">Codex bot identity; external service signs the commits.</span>
+        </div>
+        <div role="cell" data-label="Cursor">
+          <span class="cell-tag tag-light">Third-party App</span>
+          <span class="cell-note">Cursor bot identity; external service has R/W to the repo.</span>
+        </div>
+      </div>
+
+      <!-- Row 5: Templatable -->
+      <div class="matrix-row" role="row">
+        <div class="dim" role="cell">Templatable across N repos<br><small>If you have 50</small></div>
+        <div role="cell" data-label="GitHub Copilot">
+          <span class="cell-tag tag-none">Policy-driven</span>
+          <span class="cell-note">Enable once at org level; repo owners can opt out. No per-repo fan-out.</span>
+        </div>
+        <div role="cell" data-label="Claude Code">
+          <span class="cell-tag tag-heavy">Fan-out</span>
+          <span class="cell-note">Workflow file + secret must land in every repo. Org-wide secret helps; file does not.</span>
+        </div>
+        <div role="cell" data-label="Codex">
+          <span class="cell-tag tag-light">Per-repo toggle</span>
+          <span class="cell-note">Toggle each repo inside ChatGPT Codex settings. Governance lives outside GitHub.</span>
+        </div>
+        <div role="cell" data-label="Cursor">
+          <span class="cell-tag tag-light">Per-repo connect</span>
+          <span class="cell-note">Each repo connected via Cursor's GitHub integration. Governance lives outside GitHub.</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- ── Takeaway + caveats ──────────────────── -->
+<section class="section-flush-top">
+  <div class="container">
+    <div class="two-col">
+
+      <div class="callout">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="var(--gh-accent)" aria-hidden="true">
+            <path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/>
+          </svg>
+          When Copilot's setup advantage decides it
+        </h3>
+        <ul>
+          <li><strong>You have many repos.</strong> Fleet-wide enablement beats per-repo plumbing.</li>
+          <li><strong>Security reviews the agent's identity.</strong> First-party GitHub bot needs less paperwork than three external OAuth apps with R/W scopes.</li>
+          <li><strong>You already pay for Copilot.</strong> No new vendor, new invoice, or new data-processing agreement.</li>
+          <li><strong>Governance lives in GitHub.</strong> Rulesets, branch protections, and audit log cover the agent by default.</li>
+        </ul>
+      </div>
+
+      <div class="callout caveat">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="var(--gh-warn)" aria-hidden="true">
+            <path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/>
+          </svg>
+          When it doesn't
+        </h3>
+        <ul>
+          <li><strong>Capability ≠ setup cost.</strong> This card says nothing about which agent writes better code or resolves harder issues.</li>
+          <li><strong>One repo, no fleet.</strong> The per-repo workflow tax is a coffee break, not a program of work.</li>
+          <li><strong>You want a specific model.</strong> If you need Claude Opus, GPT-5, or Cursor's model pool against your repo, you need that vendor's path.</li>
+          <li><strong>Ruleset compatibility.</strong> Copilot itself can be blocked by branch-protection rules until added as a bypass actor — not zero-friction, just low-friction.</li>
+        </ul>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- ── Footer ─────────────────────────────── -->
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>A setup-cost comparison for platform leads evaluating AI coding agents on GitHub. The claim being made is narrow: <strong>GitHub Copilot has meaningfully less per-repo and per-org onboarding work than the other three</strong> because GitHub owns the surface. Every other question — code quality, model choice, cost at scale, trust — is intentionally out of scope.</p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; this is not an official Microsoft comparison and is not endorsed by GitHub, Anthropic, OpenAI, or Cursor. Published under the SME&amp;C Infographics library.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent — GitHub Docs</a></li>
+        <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
+        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub — OpenAI</a></li>
+        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/ai-coding-agent-landscape.html
+++ b/github-copilot/ai-coding-agent-landscape.html
@@ -90,43 +90,125 @@
   .sources-list { list-style: none; padding: 0; }
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="Which AI coding agent fits which team? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="Which AI coding agent fits which team?">
+<meta property="og:description" content="Which AI coding agent fits which team? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/ai-coding-agent-landscape.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Which AI coding agent fits which team?">
+<meta name="twitter:description" content="Which AI coding agent fits which team? — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <header class="hero">
   <div class="hero-badge">
     <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
-    Platform engineering · Compete landscape
+    Platform engineering · Agent control planes
   </div>
   <h1>Which AI coding agent fits which team?</h1>
-  <p>Not a ranking. A short decision tree plus four honest "when each one wins" cards. Skip this piece if you already know which vendor you're buying.</p>
-  <div class="hero-meta">Accurate as of April 2026 · Async, issue-triggered agents only (not IDE copilots)</div>
+  <p>Not a ranking. A decision tree for choosing the control plane first: GitHub-native, GitHub-hosted third-party, standalone vendor workflow, or Cursor's cloud surface.</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Async GitHub-connected agents, not local IDE copilots</div>
 </header>
 
 <section>
   <div class="container">
     <span class="section-label">Start here</span>
     <h2 class="section-title">Three questions in order</h2>
-    <p class="section-sub">Most teams short-circuit at question 1 or 2. If you're still undecided after question 3, your real constraint is probably organizational, not technical.</p>
+    <p class="section-sub">Most teams short-circuit at question 1 or 2. If you're still undecided after question 3, your real constraint is usually control plane, model preference, or existing developer workflow.</p>
 
     <div class="tree">
       <div class="tree-q">Q1 · Is GitHub.com your primary code host?</div>
-      <div class="tree-row"><div class="ans">No</div><div class="out">Stop here. Codex, Cursor Cloud Agents, and Copilot cloud agent all require GitHub-hosted repos. Claude Code Action is GitHub-only too. Your shortlist is <em>IDE-native</em> agents, not async ones — different category.</div></div>
+      <div class="tree-row"><div class="ans">No</div><div class="out">Stop here for this series. The GitHub-hosted agents and GitHub Actions patterns assume GitHub repos. Your shortlist is local IDE/CLI agents or a vendor cloud agent that supports your code host.</div></div>
       <div class="tree-row"><div class="ans">Yes</div><div class="out">Continue to Q2.</div></div>
     </div>
 
     <div class="tree tree-gap">
-      <div class="tree-q">Q2 · Do you already pay for Copilot Business or Enterprise?</div>
-      <div class="tree-row"><div class="ans">Yes</div><div class="out">Default to <strong>Copilot cloud agent</strong> for async issue→PR work. Zero per-repo setup. Keep a second tool around for the cases below.</div></div>
-      <div class="tree-row"><div class="ans">No, and we won't</div><div class="out">Continue to Q3. Copilot cloud agent requires a Copilot seat; you'll be choosing between the three remaining tools.</div></div>
+      <div class="tree-q">Q2 · Do you want the agent managed inside GitHub/Copilot?</div>
+      <div class="tree-row"><div class="ans">Yes</div><div class="out">Start with <strong>Copilot cloud agent</strong>, then evaluate GitHub-hosted Claude or Codex when model choice matters. These agents share GitHub entry points, policies, and review loops.</div></div>
+      <div class="tree-row"><div class="ans">No</div><div class="out">Continue to Q3. You are choosing a standalone vendor workflow, where dashboard, billing, setup, and audit surfaces may live outside GitHub.</div></div>
     </div>
 
     <div class="tree tree-gap">
       <div class="tree-q">Q3 · What matters most?</div>
-      <div class="tree-row"><div class="ans">Specific model</div><div class="out">If you need Claude Opus/Sonnet specifically: <strong>Claude Code Action</strong>. If GPT-5: <strong>Codex</strong>. If a model pool auto-routed: <strong>Cursor Cloud Agents</strong>.</div></div>
-      <div class="tree-row"><div class="ans">Lowest per-repo friction</div><div class="out"><strong>Codex</strong> or <strong>Cursor</strong> — no workflow YAML in-repo, per-repo toggle in their dashboards.</div></div>
-      <div class="tree-row"><div class="ans">Keep governance in GitHub</div><div class="out"><strong>Claude Code Action</strong> — it's a standard Actions workflow, so the audit trail, secret management, and permission model stay in GitHub.</div></div>
-      <div class="tree-row"><div class="ans">IDE ↔ cloud parity</div><div class="out"><strong>Cursor Cloud Agents</strong> — same agent UX in the editor and in the cloud; Slack/Linear triggers bundled.</div></div>
+      <div class="tree-row"><div class="ans">Specific model</div><div class="out">Use <strong>GitHub-hosted Claude/Codex</strong> if you want model choice inside GitHub; use standalone Claude/Codex if you need that vendor's own workflow or account controls.</div></div>
+      <div class="tree-row"><div class="ans">Lowest repo change</div><div class="out"><strong>Copilot or GitHub-hosted Claude/Codex</strong> avoid workflow YAML. Standalone Codex/Cursor also avoid workflow files, but move more setup into vendor settings.</div></div>
+      <div class="tree-row"><div class="ans">Custom CI workflow</div><div class="out"><strong>Claude Code Action</strong> is the clean fit when you want a GitHub Actions workflow, your own runner posture, and explicit secret/permission control.</div></div>
+      <div class="tree-row"><div class="ans">Editor ↔ cloud parity</div><div class="out"><strong>Cursor Cloud Agents</strong> fit teams already using Cursor and wanting the same agent surface from editor, web, Slack, Linear, or GitHub.</div></div>
     </div>
   </div>
 </section>
@@ -134,49 +216,49 @@
 <section class="section-flush-top">
   <div class="container">
     <span class="section-label">Honest fit</span>
-    <h2 class="section-title">When each one actually wins</h2>
-    <p class="section-sub">Every tool below has a real niche. The question is which niche looks like your team.</p>
+    <h2 class="section-title">When each control plane fits</h2>
+    <p class="section-sub">Every option below can be the right answer. The useful question is where you want policy, billing, setup, and review state to live.</p>
 
     <div class="picker">
 
       <div class="tool-card">
-        <header><h3>GitHub Copilot cloud agent</h3><div class="sub">First-party · Copilot Business/Enterprise</div></header>
+        <header><h3>GitHub Copilot cloud agent</h3><div class="sub">GitHub-native · Pro, Pro+, Business, Enterprise</div></header>
         <div class="body">
-          <div class="fit"><strong>Best fit:</strong> org already on Copilot, many repos, governance in GitHub, platform team wants agent adoption off their queue.</div>
-          <div class="not-fit"><strong>Worst fit:</strong> you need a specific non-Anthropic non-OpenAI model, or you've explicitly rejected Copilot for procurement reasons.</div>
+          <div class="fit"><strong>Best fit:</strong> GitHub is the control plane, Copilot is already approved, and platform wants low-friction issue-to-PR adoption across many repos.</div>
+          <div class="not-fit"><strong>Watch-outs:</strong> Copilot cloud agent still uses Actions minutes and premium requests, and it does not honor Copilot content exclusions.</div>
           <ul>
             <li>Zero per-repo files required</li>
-            <li>First-party bot identity in git log</li>
-            <li>Audit trail in GitHub's existing surfaces</li>
+            <li>First-party GitHub agent identity</li>
+            <li>GitHub agent entry points and review loop</li>
             <li>Uses Actions minutes + Copilot premium requests</li>
           </ul>
         </div>
       </div>
 
       <div class="tool-card">
-        <header><h3>Claude Code Action</h3><div class="sub">Anthropic · GitHub App + workflow</div></header>
+        <header><h3>GitHub-hosted Claude or Codex</h3><div class="sub">Third-party agents · GitHub/Copilot surface</div></header>
         <div class="body">
-          <div class="fit"><strong>Best fit:</strong> team already trusts Claude for code, wants governance in GitHub Actions, OK shipping a workflow file per repo.</div>
-          <div class="not-fit"><strong>Worst fit:</strong> 50+ repos where per-repo workflow fan-out is painful, or org policy blocks third-party GitHub Apps.</div>
+          <div class="fit"><strong>Best fit:</strong> you want Claude or Codex model choice while keeping GitHub issues, PR comments, policies, and agent management as the primary workflow.</div>
+          <div class="not-fit"><strong>Watch-outs:</strong> third-party agents are public preview and require Copilot plan eligibility plus policy enablement.</div>
           <ul>
-            <li>Workflow YAML + <code>ANTHROPIC_API_KEY</code> per repo</li>
-            <li>Responds to <code>@claude</code> in issue/PR comments</li>
-            <li>Runs on your own GitHub runners</li>
-            <li>Supports Bedrock, Vertex AI, Microsoft Foundry</li>
+            <li>Supported agents: Anthropic Claude and OpenAI Codex</li>
+            <li>Agents tab, issue assignment, PR comments, Mobile, VS Code</li>
+            <li>Same protections and limitations as Copilot cloud agent</li>
+            <li>Uses Actions minutes + Copilot premium requests</li>
           </ul>
         </div>
       </div>
 
       <div class="tool-card">
-        <header><h3>OpenAI Codex in GitHub</h3><div class="sub">External SaaS · ChatGPT account</div></header>
+        <header><h3>Standalone Claude / ChatGPT Codex</h3><div class="sub">Vendor workflow · App, settings, or Actions</div></header>
         <div class="body">
-          <div class="fit"><strong>Best fit:</strong> teams already in ChatGPT for dev work, want <code>@codex review</code> on PRs without writing Actions YAML, OK with governance in ChatGPT.</div>
-          <div class="not-fit"><strong>Worst fit:</strong> regulated orgs that need every agent action auditable inside GitHub's own logs, not a vendor dashboard.</div>
+          <div class="fit"><strong>Best fit:</strong> you already standardize on Claude Code or ChatGPT Codex and want that product's own settings, review behavior, or automation model.</div>
+          <div class="not-fit"><strong>Watch-outs:</strong> setup and audit state can split between GitHub and vendor settings, especially for standalone Codex review or Claude workflow secrets.</div>
           <ul>
-            <li>No workflow file needed</li>
-            <li>Per-repo toggle in ChatGPT Codex settings</li>
-            <li>Optional <code>AGENTS.md</code> for review guidelines</li>
-            <li>Auto-review mode for every PR opt-in</li>
+            <li>Claude Code Action uses workflow YAML + secret</li>
+            <li>ChatGPT Codex review uses Codex cloud settings</li>
+            <li><code>@claude</code> and <code>@codex review</code> patterns are both documented</li>
+            <li>Good for vendor-specific automation beyond GitHub-hosted agents</li>
           </ul>
         </div>
       </div>
@@ -184,13 +266,13 @@
       <div class="tool-card">
         <header><h3>Cursor Cloud Agents</h3><div class="sub">External SaaS · Cursor team plan</div></header>
         <div class="body">
-          <div class="fit"><strong>Best fit:</strong> Cursor IDE shop wanting the same agent UX in cloud; teams using Slack/Linear as primary issue surfaces, not GitHub.</div>
-          <div class="not-fit"><strong>Worst fit:</strong> teams not on Cursor IDE; orgs that restrict third-party R/W GitHub integrations.</div>
+          <div class="fit"><strong>Best fit:</strong> Cursor IDE shop wanting one agent experience across editor, web, Slack, Linear, and GitHub.</div>
+          <div class="not-fit"><strong>Watch-outs:</strong> Cursor's value is strongest when the team is already bought into Cursor; regulated teams should review repo access, billing, privacy, and audit requirements.</div>
           <ul>
             <li>Triggered from Cursor web, Desktop, Slack, Linear, GitHub, API</li>
-            <li>Models always run in Max Mode</li>
+            <li>Cloud agents run away from the local laptop</li>
             <li>MCP + hooks support (<code>.cursor/hooks.json</code>)</li>
-            <li>Billed at API pricing per model</li>
+            <li>Team/Enterprise plans add admin and governance controls</li>
           </ul>
         </div>
       </div>
@@ -203,9 +285,9 @@
         What this piece is not
       </h3>
       <ul>
-        <li><strong>Not a capability ranking.</strong> None of these cards claim one agent writes better code than another — that depends on your stack and benchmark.</li>
-        <li><strong>Not a pricing comparison.</strong> All four change pricing on months-long cycles; any dollar figure here would age fast.</li>
-        <li><strong>Not vendor-neutral on origin.</strong> The author is a Microsoft employee. The framing tries to be honest about where Copilot doesn't win.</li>
+        <li><strong>Not a capability ranking.</strong> None of these cards claim one agent writes better code than another; that depends on task, repo, model, and benchmark.</li>
+        <li><strong>Not a procurement recommendation.</strong> Customers still need their own legal, privacy, billing, and InfoSec review.</li>
+        <li><strong>Not one integration path per vendor.</strong> Claude and Codex now have both GitHub-hosted and standalone patterns.</li>
       </ul>
     </div>
   </div>
@@ -215,16 +297,18 @@
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>A short decision tree for platform leads evaluating async AI coding agents on GitHub. Companion to the <a href="ai-agent-setup-cost.html">setup-cost comparison</a>. The claim is narrow: <strong>most teams can pick a default in 2 questions, and the remaining choice is about model preference and where governance lives.</strong></p>
-      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+      <p>A short decision tree for platform leads evaluating async AI coding agents around GitHub. Companion to the <a href="ai-agent-setup-cost.html">setup-cost comparison</a>. The claim is narrow: <strong>choose the control plane first, then choose the agent or model inside it.</strong></p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not an official Microsoft comparison and not endorsed by GitHub, Anthropic, OpenAI, Cursor, or Anysphere.</p>
     </div>
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/about-third-party-agents">GitHub third-party agents</a></li>
         <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
-        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
-        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+        <li><a href="https://developers.openai.com/codex/integrations/github">Codex GitHub integration</a></li>
+        <li><a href="https://cursor.com/blog/cloud-agents">Cursor Cloud Agents</a></li>
+        <li><a href="https://cursor.com/pricing">Cursor pricing and plans</a></li>
       </ul>
     </div>
   </div>

--- a/github-copilot/ai-coding-agent-landscape.html
+++ b/github-copilot/ai-coding-agent-landscape.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Which AI coding agent fits which team?</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E; --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E; --gh-blue: #0969DA;
+    --gh-muted: #57606A; --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA; --gh-card: #FFFFFF;
+    --gh-warn: #9A6700;
+    --radius: 10px; --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body { font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink); background: var(--gh-surface); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--gh-blue); text-decoration: none; } a:hover { text-decoration: underline; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .hero { background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff; padding: 80px 24px 64px; text-align: center; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%); pointer-events: none; }
+  .hero-badge { display: inline-flex; align-items: center; gap: 8px; padding: 5px 14px;
+    border-radius: 20px; background: rgba(255,255,255,.10); font-size: .78rem; font-weight: 600;
+    letter-spacing: .4px; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+    margin-bottom: 20px; border: 1px solid rgba(255,255,255,.12); }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 { font-size: clamp(1.9rem, 4.2vw, 2.8rem); font-weight: 700; line-height: 1.15;
+    max-width: 820px; margin: 0 auto 14px; }
+  .hero p { font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto; }
+  .hero-meta { margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px; }
+  section { padding: 56px 0; }
+  .section-label { display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent); margin-bottom: 8px; }
+  .section-title { font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink); }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+  .section-flush-top { padding-top: 0; }
+  .tree-gap { margin-top: 20px; }
+
+  .picker { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  @media (max-width: 720px) { .picker { grid-template-columns: 1fr; } }
+  .tool-card { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden;
+    display: flex; flex-direction: column; }
+  .tool-card header { background: var(--gh-ink); color: #fff; padding: 16px 20px; }
+  .tool-card h3 { font-size: 1.1rem; font-weight: 700; margin-bottom: 2px; }
+  .tool-card header .sub { font-size: .78rem; opacity: .7; }
+  .tool-card .body { padding: 20px; display: flex; flex-direction: column; gap: 14px; flex: 1; }
+  .tool-card .fit { font-size: .9rem; color: var(--gh-ink); }
+  .tool-card .fit strong { color: var(--gh-accent); }
+  .tool-card .not-fit { font-size: .88rem; color: var(--gh-muted); }
+  .tool-card .not-fit strong { color: var(--gh-warn); }
+  .tool-card ul { padding-left: 18px; font-size: .88rem; }
+  .tool-card ul li { margin-bottom: 4px; }
+
+  .tree { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 24px; }
+  .tree-q { font-weight: 700; font-size: 1rem; color: var(--gh-ink); margin-bottom: 10px; }
+  .tree-row { display: grid; grid-template-columns: 160px 1fr; gap: 12px; padding: 10px 0;
+    border-top: 1px solid var(--gh-border); align-items: start; }
+  .tree-row:first-of-type { border-top: 0; }
+  .tree-row .ans { font-weight: 600; color: var(--gh-blue); font-size: .9rem; }
+  .tree-row .out { font-size: .9rem; color: var(--gh-ink); }
+  @media (max-width: 640px) {
+    .tree-row { grid-template-columns: 1fr; gap: 4px; }
+  }
+
+  .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-warn); border-radius: var(--radius);
+    padding: 22px; box-shadow: var(--shadow); margin-top: 24px; }
+  .callout h3 { font-size: 1.05rem; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; }
+
+  footer { background: var(--gh-ink); color: #C9D1D9; padding: 40px 24px;
+    font-size: .85rem; line-height: 1.7; }
+  footer .container { display: grid; grid-template-columns: 2fr 1fr; gap: 32px; }
+  @media (max-width: 720px) { footer .container { grid-template-columns: 1fr; } }
+  footer a { color: #58A6FF; }
+  footer h4 { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: #fff; margin-bottom: 10px; }
+  .disclosure { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E; }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    Platform engineering · Compete landscape
+  </div>
+  <h1>Which AI coding agent fits which team?</h1>
+  <p>Not a ranking. A short decision tree plus four honest "when each one wins" cards. Skip this piece if you already know which vendor you're buying.</p>
+  <div class="hero-meta">Accurate as of April 2026 · Async, issue-triggered agents only (not IDE copilots)</div>
+</header>
+
+<section>
+  <div class="container">
+    <span class="section-label">Start here</span>
+    <h2 class="section-title">Three questions in order</h2>
+    <p class="section-sub">Most teams short-circuit at question 1 or 2. If you're still undecided after question 3, your real constraint is probably organizational, not technical.</p>
+
+    <div class="tree">
+      <div class="tree-q">Q1 · Is GitHub.com your primary code host?</div>
+      <div class="tree-row"><div class="ans">No</div><div class="out">Stop here. Codex, Cursor Cloud Agents, and Copilot cloud agent all require GitHub-hosted repos. Claude Code Action is GitHub-only too. Your shortlist is <em>IDE-native</em> agents, not async ones — different category.</div></div>
+      <div class="tree-row"><div class="ans">Yes</div><div class="out">Continue to Q2.</div></div>
+    </div>
+
+    <div class="tree tree-gap">
+      <div class="tree-q">Q2 · Do you already pay for Copilot Business or Enterprise?</div>
+      <div class="tree-row"><div class="ans">Yes</div><div class="out">Default to <strong>Copilot cloud agent</strong> for async issue→PR work. Zero per-repo setup. Keep a second tool around for the cases below.</div></div>
+      <div class="tree-row"><div class="ans">No, and we won't</div><div class="out">Continue to Q3. Copilot cloud agent requires a Copilot seat; you'll be choosing between the three remaining tools.</div></div>
+    </div>
+
+    <div class="tree tree-gap">
+      <div class="tree-q">Q3 · What matters most?</div>
+      <div class="tree-row"><div class="ans">Specific model</div><div class="out">If you need Claude Opus/Sonnet specifically: <strong>Claude Code Action</strong>. If GPT-5: <strong>Codex</strong>. If a model pool auto-routed: <strong>Cursor Cloud Agents</strong>.</div></div>
+      <div class="tree-row"><div class="ans">Lowest per-repo friction</div><div class="out"><strong>Codex</strong> or <strong>Cursor</strong> — no workflow YAML in-repo, per-repo toggle in their dashboards.</div></div>
+      <div class="tree-row"><div class="ans">Keep governance in GitHub</div><div class="out"><strong>Claude Code Action</strong> — it's a standard Actions workflow, so the audit trail, secret management, and permission model stay in GitHub.</div></div>
+      <div class="tree-row"><div class="ans">IDE ↔ cloud parity</div><div class="out"><strong>Cursor Cloud Agents</strong> — same agent UX in the editor and in the cloud; Slack/Linear triggers bundled.</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="section-flush-top">
+  <div class="container">
+    <span class="section-label">Honest fit</span>
+    <h2 class="section-title">When each one actually wins</h2>
+    <p class="section-sub">Every tool below has a real niche. The question is which niche looks like your team.</p>
+
+    <div class="picker">
+
+      <div class="tool-card">
+        <header><h3>GitHub Copilot cloud agent</h3><div class="sub">First-party · Copilot Business/Enterprise</div></header>
+        <div class="body">
+          <div class="fit"><strong>Best fit:</strong> org already on Copilot, many repos, governance in GitHub, platform team wants agent adoption off their queue.</div>
+          <div class="not-fit"><strong>Worst fit:</strong> you need a specific non-Anthropic non-OpenAI model, or you've explicitly rejected Copilot for procurement reasons.</div>
+          <ul>
+            <li>Zero per-repo files required</li>
+            <li>First-party bot identity in git log</li>
+            <li>Audit trail in GitHub's existing surfaces</li>
+            <li>Uses Actions minutes + Copilot premium requests</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tool-card">
+        <header><h3>Claude Code Action</h3><div class="sub">Anthropic · GitHub App + workflow</div></header>
+        <div class="body">
+          <div class="fit"><strong>Best fit:</strong> team already trusts Claude for code, wants governance in GitHub Actions, OK shipping a workflow file per repo.</div>
+          <div class="not-fit"><strong>Worst fit:</strong> 50+ repos where per-repo workflow fan-out is painful, or org policy blocks third-party GitHub Apps.</div>
+          <ul>
+            <li>Workflow YAML + <code>ANTHROPIC_API_KEY</code> per repo</li>
+            <li>Responds to <code>@claude</code> in issue/PR comments</li>
+            <li>Runs on your own GitHub runners</li>
+            <li>Supports Bedrock, Vertex AI, Microsoft Foundry</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tool-card">
+        <header><h3>OpenAI Codex in GitHub</h3><div class="sub">External SaaS · ChatGPT account</div></header>
+        <div class="body">
+          <div class="fit"><strong>Best fit:</strong> teams already in ChatGPT for dev work, want <code>@codex review</code> on PRs without writing Actions YAML, OK with governance in ChatGPT.</div>
+          <div class="not-fit"><strong>Worst fit:</strong> regulated orgs that need every agent action auditable inside GitHub's own logs, not a vendor dashboard.</div>
+          <ul>
+            <li>No workflow file needed</li>
+            <li>Per-repo toggle in ChatGPT Codex settings</li>
+            <li>Optional <code>AGENTS.md</code> for review guidelines</li>
+            <li>Auto-review mode for every PR opt-in</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tool-card">
+        <header><h3>Cursor Cloud Agents</h3><div class="sub">External SaaS · Cursor team plan</div></header>
+        <div class="body">
+          <div class="fit"><strong>Best fit:</strong> Cursor IDE shop wanting the same agent UX in cloud; teams using Slack/Linear as primary issue surfaces, not GitHub.</div>
+          <div class="not-fit"><strong>Worst fit:</strong> teams not on Cursor IDE; orgs that restrict third-party R/W GitHub integrations.</div>
+          <ul>
+            <li>Triggered from Cursor web, Desktop, Slack, Linear, GitHub, API</li>
+            <li>Models always run in Max Mode</li>
+            <li>MCP + hooks support (<code>.cursor/hooks.json</code>)</li>
+            <li>Billed at API pricing per model</li>
+          </ul>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="callout">
+      <h3>
+        <svg viewBox="0 0 16 16" fill="#9A6700" aria-hidden="true"><path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/></svg>
+        What this piece is not
+      </h3>
+      <ul>
+        <li><strong>Not a capability ranking.</strong> None of these cards claim one agent writes better code than another — that depends on your stack and benchmark.</li>
+        <li><strong>Not a pricing comparison.</strong> All four change pricing on months-long cycles; any dollar figure here would age fast.</li>
+        <li><strong>Not vendor-neutral on origin.</strong> The author is a Microsoft employee. The framing tries to be honest about where Copilot doesn't win.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>A short decision tree for platform leads evaluating async AI coding agents on GitHub. Companion to the <a href="ai-agent-setup-cost.html">setup-cost comparison</a>. The claim is narrow: <strong>most teams can pick a default in 2 questions, and the remaining choice is about model preference and where governance lives.</strong></p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; not endorsed by GitHub, Anthropic, OpenAI, or Cursor.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent</a></li>
+        <li><a href="https://code.claude.com/docs/en/github-actions">Claude Code GitHub Actions</a></li>
+        <li><a href="https://developers.openai.com/codex/cloud/code-review">Codex in GitHub</a></li>
+        <li><a href="https://cursor.com/docs/cloud-agent">Cursor Cloud Agents</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/copilot-learn-mcp-dogfood.html
+++ b/github-copilot/copilot-learn-mcp-dogfood.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Copilot + Microsoft Learn: how this site stays accurate</title>
+<title>Copilot + Microsoft Learn: how this site schedules accuracy work</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
@@ -62,6 +62,14 @@
     .step:not(:last-child)::after { content: '→'; position: absolute; right: -8px; top: 28px;
       color: var(--gh-border); font-size: 1.4rem; font-weight: 700; }
   }
+  @media (max-width: 820px) {
+    .pipeline { padding: 20px; }
+    .step { display: grid; grid-template-columns: 42px 1fr; column-gap: 12px; text-align: left; padding: 14px 0; }
+    .step:not(:last-child) { border-bottom: 1px solid var(--gh-border); }
+    .step-num { grid-row: span 2; margin-bottom: 0; }
+    .step h4 { font-size: .96rem; margin-bottom: 4px; }
+    .step p { font-size: .86rem; }
+  }
   .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
   @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
   .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
@@ -86,59 +94,141 @@
   .sources-list { list-style: none; padding: 0; }
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
+<script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
+<style>/* smec-back-btn v1 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
+  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
+  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  /* Collapsing: wait for the label to fade out, then shrink the pill. */
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto;
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+.smec-back-btn__label { max-width: 0; opacity: 0;
+  /* Collapsing: label fades out first, then its width collapses with the pill. */
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+
+/* Expanding: pill and label grow together in one motion; text appears near the end. */
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  gap: 10px; padding: 0 18px 0 12px;
+  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  transition:
+    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    background 0.35s ease 0s,
+    box-shadow 0.35s ease 0s; }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__icon,
+.smec-back-btn:focus-visible .smec-back-btn__icon {
+  transform: translateX(-2px);
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
+.smec-back-btn:hover .smec-back-btn__label,
+.smec-back-btn:focus-visible .smec-back-btn__label {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.3s ease 0.3s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
+  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
+  .smec-back-btn:hover, .smec-back-btn:focus-visible,
+  .smec-back-btn:hover .smec-back-btn__icon,
+  .smec-back-btn:focus-visible .smec-back-btn__icon,
+  .smec-back-btn:hover .smec-back-btn__label,
+  .smec-back-btn:focus-visible .smec-back-btn__label {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
+<!-- smec-meta v1 -->
+<meta name="description" content="Copilot + Microsoft Learn: how this site schedules accuracy work — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:title" content="Copilot + Microsoft Learn: how this site schedules accuracy work">
+<meta property="og:description" content="Copilot + Microsoft Learn: how this site schedules accuracy work — an interactive infographic from the SME&amp;C Infographic Hub.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://sme-c-infographics.github.io/github-copilot/copilot-learn-mcp-dogfood.html">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Copilot + Microsoft Learn: how this site schedules accuracy work">
+<meta name="twitter:description" content="Copilot + Microsoft Learn: how this site schedules accuracy work — an interactive infographic from the SME&amp;C Infographic Hub.">
+<!-- smec-favicon v1 -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<!-- smec-accuracy v1 -->
+<meta name="smec:last-accuracy-check" content="2026-04-30">
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+
 
 <header class="hero">
   <div class="hero-badge">
     <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
     Dogfood evidence · This repo
   </div>
-  <h1>How this site stays accurate, automatically</h1>
-  <p>A scheduled loop: GitHub Actions fires, Copilot cloud agent reads each page, verifies claims against Microsoft Learn, and drafts a PR if facts are stale. The human step is review, not research.</p>
-  <div class="hero-meta">Accurate as of April 2026 · Evidence: this repository's workflow history</div>
+  <h1>How this site schedules accuracy work</h1>
+  <p>A scheduled loop creates review issues, gives Copilot enough context to propose fixes when assignment is configured, and keeps humans in the approval seat. The automation reduces discovery work; it does not guarantee a correct PR.</p>
+  <div class="hero-meta">Accurate as of April 30, 2026 · Evidence: this repository's workflow files</div>
 </header>
 
 <div class="container">
   <div class="big-stat">
-    <div class="num">20</div>
-    <div class="num-sub">pages under automated accuracy review</div>
-    <div class="num-caption">Every infographic gets a scheduled Copilot-assigned issue. Copilot reads the page, verifies claims against Microsoft Learn, and drafts a PR if anything looks stale. Two cooperating workflows in <code>.github/workflows/</code> — real infrastructure, not magic.</div>
+    <div class="num">2</div>
+    <div class="num-sub">scheduled review loops in this repo</div>
+    <div class="num-caption"><code>accuracy-review.yml</code> checks stale accuracy metadata weekly. <code>copilot-page-review.yml</code> turns monthly audit findings into review issues. Copilot assignment is PAT-dependent; PR creation is the intended next step, not a YAML-level guarantee.</div>
   </div>
 </div>
 
 <section>
   <div class="container">
     <span class="section-label">The loop</span>
-    <h2 class="section-title">Five steps from cron tick to drafted PR</h2>
-    <p class="section-sub">Everything runs inside the repository. No external SaaS dashboard, no out-of-band workflow. The agent's identity, scope, and outputs are all inspectable in git history.</p>
+    <h2 class="section-title">Five steps from cron tick to review issue</h2>
+    <p class="section-sub">The durable handoff is the GitHub issue. If Copilot assignment is available and a user-scoped PAT is configured, that issue can start agent work; otherwise it remains visible for a human to assign or handle.</p>
 
     <div class="pipeline">
       <div class="pipeline-steps">
         <div class="step">
           <div class="step-num">1</div>
           <h4>Scheduled trigger</h4>
-          <p>Cron in <code>accuracy-review.yml</code> fires weekly (Thursday 07:00 UTC), caps at 10 issues per run.</p>
+          <p><code>accuracy-review.yml</code> runs weekly on Thursdays. <code>copilot-page-review.yml</code> runs monthly on the 1st.</p>
         </div>
         <div class="step">
           <div class="step-num">2</div>
-          <h4>Issues created</h4>
-          <p>One issue per stale page, labeled <code>copilot-review</code>, assigned to <code>Copilot</code> via a user-scoped PAT.</p>
+          <h4>Review bodies built</h4>
+          <p>Scripts emit issue bodies from stale accuracy metadata or audit findings, with per-run caps and duplicate checks.</p>
         </div>
         <div class="step">
           <div class="step-num">3</div>
-          <h4>Copilot picks up</h4>
-          <p>Cloud agent detects the assignment, spins an ephemeral Actions environment, reads the page.</p>
+          <h4>Issues opened</h4>
+          <p>Weekly issues use <code>accuracy-review</code>; monthly issues use <code>copilot-review</code>. Both include hidden page markers for deduplication.</p>
         </div>
         <div class="step">
           <div class="step-num">4</div>
-          <h4>Verify against Learn</h4>
-          <p>Checks current product state on Microsoft Learn (via MCP when configured, or web fetch) and compares to the page's claims.</p>
+          <h4>Assignment attempted</h4>
+          <p>If <code>COPILOT_ASSIGN_TOKEN</code> exists and Copilot is assignable, the workflow assigns Copilot. Without the PAT, issues are intentionally left unassigned.</p>
         </div>
         <div class="step">
           <div class="step-num">5</div>
-          <h4>Draft PR</h4>
-          <p>If stale claims found, opens a <code>copilot/accuracy-review-*</code> branch with edits + rationale. No auto-merge.</p>
+          <h4>PR remains reviewed</h4>
+          <p>Copilot may open a draft PR with corrections and citations. Humans still merge, close, or ask for another round.</p>
         </div>
       </div>
     </div>
@@ -155,10 +245,10 @@
           Why this shape works
         </h3>
         <ul>
-          <li><strong>Zero human effort per review cycle.</strong> The cron, the assignment, and the PR draft all happen without anyone on keyboard.</li>
-          <li><strong>Microsoft Learn is a first-party source.</strong> Not general web search — a Microsoft-owned documentation surface that tracks renames, GA dates, deprecations.</li>
-          <li><strong>Evidence stays in the repo.</strong> Every review run leaves an issue, a branch, and (if stale) a PR. The audit trail is <code>git log</code>.</li>
-          <li><strong>Humans still approve.</strong> Nothing auto-merges. Every PR needs a reviewer to accept the fact-check.</li>
+          <li><strong>Zero manual scheduling.</strong> Cron finds stale pages and audit findings without someone remembering to start the review cycle.</li>
+          <li><strong>Microsoft Learn is the expected source family.</strong> The weekly issue prompt asks Copilot to verify against current Learn documentation; Learn MCP can help when configured, but the workflow does not depend on MCP.</li>
+          <li><strong>Failure is visible.</strong> Without <code>COPILOT_ASSIGN_TOKEN</code>, the workflow creates unassigned issues instead of pretending Copilot started.</li>
+          <li><strong>Humans still approve.</strong> Nothing auto-merges. Every PR needs a reviewer to accept or reject the fact-check.</li>
         </ul>
       </div>
 
@@ -168,10 +258,10 @@
           What it doesn't do
         </h3>
         <ul>
-          <li><strong>Not free.</strong> Two workflows totalling ~700 lines of YAML + a PAT secret + Copilot seats + Actions minutes. Worth it here because it amortizes across every future page.</li>
+          <li><strong>Not guaranteed PR creation.</strong> The workflows create issues. Copilot PRs require assignment to trigger, agent availability, and a task that results in edits.</li>
           <li><strong>Not perfect.</strong> Copilot can miss subtle inaccuracies or flag false positives. Review quality still depends on the reviewer.</li>
-          <li><strong>Not portable as-is.</strong> This pattern fits Microsoft-employee content about Microsoft products. Your mileage will vary for non-MS domains.</li>
-          <li><strong>Not a substitute for SME review.</strong> A correctly-cited stale fact is still stale — Learn itself lags the live product in edge cases.</li>
+          <li><strong>Not fully portable as-is.</strong> This pattern fits public documentation-heavy content. Other domains may need different source rules and reviewers.</li>
+          <li><strong>Not a substitute for SME review.</strong> A correctly cited stale fact is still stale if the source lags the live product.</li>
         </ul>
       </div>
 
@@ -183,7 +273,7 @@
   <div class="container">
     <div>
       <h4>About this infographic</h4>
-      <p>This is the lived example, not a pitch. The workflow described here runs on <a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io">this repository</a>. The claim is narrow: <strong>a monthly Copilot + Learn MCP loop removes the researcher-human from routine accuracy maintenance, at the cost of one workflow file and some platform setup.</strong></p>
+      <p>This is the lived example, not a pitch. The workflow described here runs on <a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io">this repository</a>. The claim is narrow: <strong>weekly freshness checks and monthly page audits turn accuracy work into visible GitHub issues, and can trigger Copilot drafting when PAT-based assignment and agent access are configured.</strong></p>
       <p class="disclosure">Produced by a Microsoft employee. Views are my own; this is not an official Microsoft artifact. The workflow and its results are public in the repository's history.</p>
     </div>
     <div>
@@ -191,6 +281,7 @@
       <ul class="sources-list">
         <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/accuracy-review.yml">accuracy-review.yml (weekly · Learn)</a></li>
         <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/copilot-page-review.yml">copilot-page-review.yml (monthly · audit findings)</a></li>
+        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/scripts/check-accuracy-staleness.py">check-accuracy-staleness.py</a></li>
         <li><a href="https://learn.microsoft.com/en-us/training/support/mcp">Microsoft Learn MCP server</a></li>
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent docs</a></li>
       </ul>

--- a/github-copilot/copilot-learn-mcp-dogfood.html
+++ b/github-copilot/copilot-learn-mcp-dogfood.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Copilot + Learn MCP: how this site stays accurate</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --gh-ink: #24292E; --gh-ink-2: #1B1F23;
+    --gh-accent: #2DA44E; --gh-blue: #0969DA;
+    --gh-muted: #57606A; --gh-border: #D0D7DE;
+    --gh-surface: #F6F8FA; --gh-card: #FFFFFF;
+    --gh-ok: #1A7F37; --gh-warn: #9A6700; --gh-danger: #CF222E;
+    --radius: 10px; --shadow: 0 1px 3px rgba(27,31,36,.08), 0 4px 12px rgba(27,31,36,.06);
+  }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+  body { font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--gh-ink); background: var(--gh-surface); line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  a { color: var(--gh-blue); text-decoration: none; } a:hover { text-decoration: underline; }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .hero { background: linear-gradient(135deg, #24292E 0%, #1B1F23 55%, #0B1014 100%);
+    color: #fff; padding: 80px 24px 64px; text-align: center; position: relative; overflow: hidden; }
+  .hero::before { content: ''; position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 20% 20%, rgba(45,164,78,.12) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 80%, rgba(9,105,218,.10) 0%, transparent 55%); pointer-events: none; }
+  .hero-badge { display: inline-flex; align-items: center; gap: 8px; padding: 5px 14px;
+    border-radius: 20px; background: rgba(255,255,255,.10); font-size: .78rem; font-weight: 600;
+    letter-spacing: .4px; -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+    margin-bottom: 20px; border: 1px solid rgba(255,255,255,.12); }
+  .hero-badge svg { width: 14px; height: 14px; fill: #2DA44E; }
+  .hero h1 { font-size: clamp(1.9rem, 4.2vw, 2.8rem); font-weight: 700; line-height: 1.15;
+    max-width: 820px; margin: 0 auto 14px; }
+  .hero p { font-size: 1.05rem; opacity: .85; max-width: 680px; margin: 0 auto; }
+  .hero-meta { margin-top: 24px; font-size: .8rem; opacity: .6; letter-spacing: .3px; }
+  section { padding: 56px 0; }
+  .section-flush-top { padding-top: 0; }
+  .section-label { display: inline-block; font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .12em; color: var(--gh-accent); margin-bottom: 8px; }
+  .section-title { font-size: clamp(1.4rem, 2.6vw, 1.9rem); font-weight: 700;
+    margin-bottom: 10px; color: var(--gh-ink); }
+  .section-sub { color: var(--gh-muted); max-width: 720px; margin-bottom: 32px; }
+  .big-stat { background: var(--gh-card); border: 1px solid var(--gh-border); border-radius: var(--radius);
+    box-shadow: var(--shadow); padding: 36px 28px; margin-top: -32px; position: relative; z-index: 2; text-align: center; }
+  .big-stat .num { font-size: clamp(2.4rem, 5.5vw, 3.6rem); font-weight: 800;
+    color: var(--gh-accent); line-height: 1; letter-spacing: -.02em; }
+  .big-stat .num-sub { font-size: 1rem; color: var(--gh-ink); margin-top: 8px; font-weight: 600; }
+  .big-stat .num-caption { font-size: .9rem; color: var(--gh-muted); margin-top: 4px; }
+  .pipeline { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-radius: var(--radius); box-shadow: var(--shadow); padding: 28px; }
+  .pipeline-steps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0; position: relative; }
+  @media (max-width: 820px) { .pipeline-steps { grid-template-columns: 1fr; gap: 12px; } }
+  .step { text-align: center; padding: 16px 10px; position: relative; }
+  .step-num { display: inline-flex; align-items: center; justify-content: center;
+    width: 40px; height: 40px; border-radius: 50%; background: var(--gh-ink); color: #fff;
+    font-weight: 700; font-size: .95rem; margin-bottom: 10px; }
+  .step h4 { font-size: .9rem; margin-bottom: 6px; color: var(--gh-ink); }
+  .step p { font-size: .78rem; color: var(--gh-muted); line-height: 1.5; }
+  .step code { background: var(--gh-surface); padding: 1px 5px; border-radius: 4px; font-size: .72rem; }
+  @media (min-width: 821px) {
+    .step:not(:last-child)::after { content: '→'; position: absolute; right: -8px; top: 28px;
+      color: var(--gh-border); font-size: 1.4rem; font-weight: 700; }
+  }
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  @media (max-width: 720px) { .two-col { grid-template-columns: 1fr; } }
+  .callout { background: var(--gh-card); border: 1px solid var(--gh-border);
+    border-left: 4px solid var(--gh-accent); border-radius: var(--radius);
+    padding: 22px 22px; box-shadow: var(--shadow); }
+  .callout.caveat { border-left-color: var(--gh-warn); }
+  .callout h3 { font-size: 1.05rem; margin-bottom: 10px; color: var(--gh-ink);
+    display: flex; align-items: center; gap: 8px; }
+  .callout h3 svg { width: 18px; height: 18px; flex: 0 0 auto; }
+  .callout ul { padding-left: 18px; }
+  .callout li { margin-bottom: 8px; font-size: .92rem; color: var(--gh-ink); }
+  .callout li:last-child { margin-bottom: 0; }
+  footer { background: var(--gh-ink); color: #C9D1D9; padding: 40px 24px;
+    font-size: .85rem; line-height: 1.7; }
+  footer .container { display: grid; grid-template-columns: 2fr 1fr; gap: 32px; }
+  @media (max-width: 720px) { footer .container { grid-template-columns: 1fr; } }
+  footer a { color: #58A6FF; }
+  footer h4 { font-size: .78rem; text-transform: uppercase;
+    letter-spacing: .08em; color: #fff; margin-bottom: 10px; }
+  .disclosure { margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.12);
+    font-size: .78rem; color: #8B949E; }
+  .sources-list { list-style: none; padding: 0; }
+  .sources-list li { margin-bottom: 6px; font-size: .82rem; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="hero-badge">
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+    Dogfood evidence · This repo
+  </div>
+  <h1>How this site stays accurate, automatically</h1>
+  <p>A monthly loop: GitHub Actions fires, Copilot coding agent reads each page, consults Microsoft Learn via MCP, and drafts a PR if facts are stale. The human step is review, not research.</p>
+  <div class="hero-meta">Accurate as of April 2026 · Evidence: this repository's workflow history</div>
+</header>
+
+<div class="container">
+  <div class="big-stat">
+    <div class="num">14</div>
+    <div class="num-sub">infographics under automated monthly accuracy review</div>
+    <div class="num-caption">Every page in this repo gets a scheduled Copilot-assigned issue. Copilot consults Microsoft Learn MCP, checks for stale facts, and drafts a PR if anything looks wrong. The workflow itself is ~300 lines of YAML — real infrastructure, not magic.</div>
+  </div>
+</div>
+
+<section>
+  <div class="container">
+    <span class="section-label">The loop</span>
+    <h2 class="section-title">Five steps from cron tick to drafted PR</h2>
+    <p class="section-sub">Everything runs inside the repository. No external SaaS dashboard, no out-of-band workflow. The agent's identity, scope, and outputs are all inspectable in git history.</p>
+
+    <div class="pipeline">
+      <div class="pipeline-steps">
+        <div class="step">
+          <div class="step-num">1</div>
+          <h4>Scheduled trigger</h4>
+          <p>Cron in <code>copilot-page-review.yml</code> fires monthly. Caps at 25 issues per run.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">2</div>
+          <h4>Issues created</h4>
+          <p>One issue per page, labeled <code>copilot-review</code>, assigned to <code>Copilot</code> via PAT.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
+          <h4>Copilot picks up</h4>
+          <p>Coding agent detects assignment, spins an ephemeral Actions environment, reads the page.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">4</div>
+          <h4>Learn MCP lookup</h4>
+          <p>Queries Microsoft Learn MCP for current product state; compares to the HTML's claims.</p>
+        </div>
+        <div class="step">
+          <div class="step-num">5</div>
+          <h4>Draft PR</h4>
+          <p>If stale claims found, opens a <code>copilot/accuracy-review-*</code> branch with edits + rationale.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-flush-top">
+  <div class="container">
+    <div class="two-col">
+
+      <div class="callout">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#2DA44E" aria-hidden="true"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zm3.78 5.97L7.5 10.25l-2.28-2.28a.75.75 0 10-1.06 1.06l2.81 2.81a.75.75 0 001.06 0l4.81-4.81a.75.75 0 10-1.06-1.06z"/></svg>
+          Why this shape works
+        </h3>
+        <ul>
+          <li><strong>Zero human effort per review cycle.</strong> The cron, the assignment, and the PR draft all happen without anyone on keyboard.</li>
+          <li><strong>Learn MCP is a first-party source.</strong> Not a general web search — a Microsoft-owned documentation surface that tracks renames, GA dates, deprecations.</li>
+          <li><strong>Evidence stays in the repo.</strong> Every review run leaves an issue, a branch, and (if stale) a PR. The audit trail is <code>git log</code>.</li>
+          <li><strong>Humans still approve.</strong> Nothing auto-merges. Every PR needs a reviewer to accept the fact-check.</li>
+        </ul>
+      </div>
+
+      <div class="callout caveat">
+        <h3>
+          <svg viewBox="0 0 16 16" fill="#9A6700" aria-hidden="true"><path d="M8 1.45l6.705 11.55H1.295L8 1.45zm0-1.45L0 14h16L8 0zm1 11H7v-2h2v2zm0-3H7V5h2v3z"/></svg>
+          What it doesn't do
+        </h3>
+        <ul>
+          <li><strong>Not free.</strong> ~300 lines of YAML + a PAT secret + Copilot Business seats + Actions minutes. Worth it here because it amortizes across every future page.</li>
+          <li><strong>Not perfect.</strong> Copilot can miss subtle inaccuracies or flag false positives. Review quality still depends on the reviewer.</li>
+          <li><strong>Not portable as-is.</strong> This pattern fits Microsoft-employee content about Microsoft products. Your mileage will vary for non-MS domains.</li>
+          <li><strong>Not a substitute for SME review.</strong> A correctly-cited stale fact is still stale — Learn itself lags the live product in edge cases.</li>
+        </ul>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>
+      <h4>About this infographic</h4>
+      <p>This is the lived example, not a pitch. The workflow described here runs on <a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io">this repository</a>. The claim is narrow: <strong>a monthly Copilot + Learn MCP loop removes the researcher-human from routine accuracy maintenance, at the cost of one workflow file and some platform setup.</strong></p>
+      <p class="disclosure">Produced by a Microsoft employee. Views are my own; this is not an official Microsoft artifact. The workflow and its results are public in the repository's history.</p>
+    </div>
+    <div>
+      <h4>Primary sources</h4>
+      <ul class="sources-list">
+        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/copilot-page-review.yml">copilot-page-review.yml</a></li>
+        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/accuracy-review.yml">accuracy-review.yml</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/training/support/mcp">Microsoft Learn MCP</a></li>
+        <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent docs</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/github-copilot/copilot-learn-mcp-dogfood.html
+++ b/github-copilot/copilot-learn-mcp-dogfood.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Copilot + Learn MCP: how this site stays accurate</title>
+<title>Copilot + Microsoft Learn: how this site stays accurate</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
@@ -95,15 +95,15 @@
     Dogfood evidence · This repo
   </div>
   <h1>How this site stays accurate, automatically</h1>
-  <p>A monthly loop: GitHub Actions fires, Copilot coding agent reads each page, consults Microsoft Learn via MCP, and drafts a PR if facts are stale. The human step is review, not research.</p>
+  <p>A scheduled loop: GitHub Actions fires, Copilot cloud agent reads each page, verifies claims against Microsoft Learn, and drafts a PR if facts are stale. The human step is review, not research.</p>
   <div class="hero-meta">Accurate as of April 2026 · Evidence: this repository's workflow history</div>
 </header>
 
 <div class="container">
   <div class="big-stat">
-    <div class="num">14</div>
-    <div class="num-sub">infographics under automated monthly accuracy review</div>
-    <div class="num-caption">Every page in this repo gets a scheduled Copilot-assigned issue. Copilot consults Microsoft Learn MCP, checks for stale facts, and drafts a PR if anything looks wrong. The workflow itself is ~300 lines of YAML — real infrastructure, not magic.</div>
+    <div class="num">20</div>
+    <div class="num-sub">pages under automated accuracy review</div>
+    <div class="num-caption">Every infographic gets a scheduled Copilot-assigned issue. Copilot reads the page, verifies claims against Microsoft Learn, and drafts a PR if anything looks stale. Two cooperating workflows in <code>.github/workflows/</code> — real infrastructure, not magic.</div>
   </div>
 </div>
 
@@ -118,27 +118,27 @@
         <div class="step">
           <div class="step-num">1</div>
           <h4>Scheduled trigger</h4>
-          <p>Cron in <code>copilot-page-review.yml</code> fires monthly. Caps at 25 issues per run.</p>
+          <p>Cron in <code>accuracy-review.yml</code> fires weekly (Thursday 07:00 UTC), caps at 10 issues per run.</p>
         </div>
         <div class="step">
           <div class="step-num">2</div>
           <h4>Issues created</h4>
-          <p>One issue per page, labeled <code>copilot-review</code>, assigned to <code>Copilot</code> via PAT.</p>
+          <p>One issue per stale page, labeled <code>copilot-review</code>, assigned to <code>Copilot</code> via a user-scoped PAT.</p>
         </div>
         <div class="step">
           <div class="step-num">3</div>
           <h4>Copilot picks up</h4>
-          <p>Coding agent detects assignment, spins an ephemeral Actions environment, reads the page.</p>
+          <p>Cloud agent detects the assignment, spins an ephemeral Actions environment, reads the page.</p>
         </div>
         <div class="step">
           <div class="step-num">4</div>
-          <h4>Learn MCP lookup</h4>
-          <p>Queries Microsoft Learn MCP for current product state; compares to the HTML's claims.</p>
+          <h4>Verify against Learn</h4>
+          <p>Checks current product state on Microsoft Learn (via MCP when configured, or web fetch) and compares to the page's claims.</p>
         </div>
         <div class="step">
           <div class="step-num">5</div>
           <h4>Draft PR</h4>
-          <p>If stale claims found, opens a <code>copilot/accuracy-review-*</code> branch with edits + rationale.</p>
+          <p>If stale claims found, opens a <code>copilot/accuracy-review-*</code> branch with edits + rationale. No auto-merge.</p>
         </div>
       </div>
     </div>
@@ -156,7 +156,7 @@
         </h3>
         <ul>
           <li><strong>Zero human effort per review cycle.</strong> The cron, the assignment, and the PR draft all happen without anyone on keyboard.</li>
-          <li><strong>Learn MCP is a first-party source.</strong> Not a general web search — a Microsoft-owned documentation surface that tracks renames, GA dates, deprecations.</li>
+          <li><strong>Microsoft Learn is a first-party source.</strong> Not general web search — a Microsoft-owned documentation surface that tracks renames, GA dates, deprecations.</li>
           <li><strong>Evidence stays in the repo.</strong> Every review run leaves an issue, a branch, and (if stale) a PR. The audit trail is <code>git log</code>.</li>
           <li><strong>Humans still approve.</strong> Nothing auto-merges. Every PR needs a reviewer to accept the fact-check.</li>
         </ul>
@@ -168,7 +168,7 @@
           What it doesn't do
         </h3>
         <ul>
-          <li><strong>Not free.</strong> ~300 lines of YAML + a PAT secret + Copilot Business seats + Actions minutes. Worth it here because it amortizes across every future page.</li>
+          <li><strong>Not free.</strong> Two workflows totalling ~700 lines of YAML + a PAT secret + Copilot seats + Actions minutes. Worth it here because it amortizes across every future page.</li>
           <li><strong>Not perfect.</strong> Copilot can miss subtle inaccuracies or flag false positives. Review quality still depends on the reviewer.</li>
           <li><strong>Not portable as-is.</strong> This pattern fits Microsoft-employee content about Microsoft products. Your mileage will vary for non-MS domains.</li>
           <li><strong>Not a substitute for SME review.</strong> A correctly-cited stale fact is still stale — Learn itself lags the live product in edge cases.</li>
@@ -189,9 +189,9 @@
     <div>
       <h4>Primary sources</h4>
       <ul class="sources-list">
-        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/copilot-page-review.yml">copilot-page-review.yml</a></li>
-        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/accuracy-review.yml">accuracy-review.yml</a></li>
-        <li><a href="https://learn.microsoft.com/en-us/training/support/mcp">Microsoft Learn MCP</a></li>
+        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/accuracy-review.yml">accuracy-review.yml (weekly · Learn)</a></li>
+        <li><a href="https://github.com/SME-C-Infographics/sme-c-infographics.github.io/blob/main/.github/workflows/copilot-page-review.yml">copilot-page-review.yml (monthly · audit findings)</a></li>
+        <li><a href="https://learn.microsoft.com/en-us/training/support/mcp">Microsoft Learn MCP server</a></li>
         <li><a href="https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent">Copilot cloud agent docs</a></li>
       </ul>
     </div>

--- a/manifest.json
+++ b/manifest.json
@@ -52,7 +52,32 @@
   },
   "github-copilot": {
     "displayName": "GitHub Copilot",
-    "items": []
+    "items": [
+      {
+        "file": "agent-commit-identity.html",
+        "title": "Who authored this PR? Agent identity on GitHub"
+      },
+      {
+        "file": "agent-correction-loop.html",
+        "title": "When the agent's PR is wrong: the correction loop"
+      },
+      {
+        "file": "agent-governance-surface.html",
+        "title": "Where does the agent's audit trail live?"
+      },
+      {
+        "file": "ai-agent-setup-cost.html",
+        "title": "Setup cost to first PR: AI coding agents on GitHub"
+      },
+      {
+        "file": "ai-coding-agent-landscape.html",
+        "title": "Which AI coding agent fits which team?"
+      },
+      {
+        "file": "copilot-learn-mcp-dogfood.html",
+        "title": "Copilot + Microsoft Learn: how this site schedules accuracy work"
+      }
+    ]
   },
   "avd": {
     "displayName": "AVD",


### PR DESCRIPTION
## Purpose
This PR introduces a new six-page GitHub Copilot agent infographic series for SME&C conversations about async coding agents on GitHub.

The goal is to give customers and field teams a neutral, sourced way to understand how these agent workflows differ: where they are controlled, what setup they require, how review/correction works, and what governance or audit surfaces need attention.

## What's included
- Six new GitHub Copilot category pages covering agent fit, setup cost, governance surface, commit identity, correction loops, and this repo's Copilot/Learn accuracy-review workflow.
- A populated `github-copilot` manifest category so the new pages appear on the homepage.
- A claim matrix documenting the accuracy pass and source set used for the series.

## Accuracy and positioning
The final pass reframes the series around agent control planes rather than a simple "Copilot vs third-party vendors" comparison:
- GitHub-native Copilot cloud agent
- GitHub-hosted Claude/Codex agents
- Standalone vendor integrations like Claude Code Action, ChatGPT Codex, and Cursor Cloud Agents

It also softens customer-facing language, removes "worst fit" framing, clarifies caveats like PAT-dependent Copilot assignment, and adds source links for the revised claims.

## Verification
- `git diff --check`
- `python scripts/audit-pages.py`
- `python scripts/ensure-a11y.py --check`
- `python scripts/check-links.py --check --timeout 12 --workers 16`
- `python scripts/check-accuracy-staleness.py --only github-copilot`
- Desktop/mobile browser checks for the new GitHub Copilot pages

## Note
`python scripts/check-deprecated-terms.py --check` still reports low-severity existing terminology hits in `foundry/microsoft-ai-decision-guide.html`; none are from this series.