### PR TITLE
feat: per-page smec-keep-term exception marker for deprecated-terms checker

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,124 @@
+# Copilot Instructions — SME&C Infographics
+
+Static GitHub Pages site (no build step, no framework, no package manager). Each
+infographic is a **fully self-contained HTML file** with inline CSS / SVG / JS,
+dropped into a category folder at the repo root (`azure-databases/`, `fabric/`,
+`foundry/`, `github-copilot/`, `avd/`, `app-platform-services/`,
+`defender-for-cloud/`, `azure-sql/`, `events/`, `infrastructure/`).
+`index.html` is the library landing page; `manifest.json` is the generated
+catalog it reads from.
+
+## Architecture: site chrome is automated, not hand-edited
+
+Per-page chrome (analytics, floating back button, SEO/OG meta block, favicon,
+manifest entry) is **injected by Python scripts in `scripts/`**, not by the
+contributor. Don't hand-edit these blocks in HTML files — re-run the relevant
+script instead.
+
+Every chrome script follows the same contract (see
+`docs/automated-page-updates.md`):
+
+1. **Idempotent** — running twice is a no-op the second time.
+2. Carries a **version marker** the script greps for to detect prior injections,
+   e.g. `<!-- smec-meta v1 -->`, `<!-- smec-favicon v1 -->`,
+   `data-smec-back-button="v1"`, `data-website-id=<umami-id>`,
+   `<!-- smec-tmpl:<id> -->` for bulk templating.
+3. Supports `--check` (exits non-zero if any file is missing the expected
+   state, modifies nothing) — this is what CI calls.
+4. **Skips** redirect stubs (`<meta http-equiv="refresh">`), the root
+   `index.html`, and the `.git`, `node_modules`, `.github` directories.
+
+When adding a new chrome script, mirror this contract or it will not fit the
+existing CI wiring (`ensure-site-chrome.yml`, `fix-site-chrome-pr.yml`,
+`audit-site.yml`).
+
+Read-only auditors (`audit-pages.py`, `check-links.py`,
+`check-deprecated-terms.py`, `ensure-a11y.py`, `check-accuracy-staleness.py`)
+emit JSON / Markdown into `reports/` so results can be diffed and uploaded as
+CI artifacts.
+
+## Common commands
+
+```bash
+# Apply all site chrome locally (what post-merge CI runs)
+python3 scripts/ensure-tracking.py
+python3 scripts/ensure-back-button.py
+python3 scripts/ensure-meta.py
+python3 scripts/ensure-favicon.py
+python3 scripts/generate-manifest.py
+
+# Verify a single chrome rule without modifying anything (CI-equivalent)
+python3 scripts/ensure-meta.py --check
+
+# Run an auditor (writes JSON under reports/)
+python3 scripts/audit-pages.py
+python3 scripts/check-links.py
+python3 scripts/check-deprecated-terms.py            # report only
+python3 scripts/check-deprecated-terms.py --apply    # rewrite (review first!)
+python3 scripts/ensure-a11y.py
+python3 scripts/check-accuracy-staleness.py --max-age-days 28
+
+# Bulk HTML edits via a JSON spec (see scripts/specs/example.json)
+python3 scripts/apply-template-change.py scripts/specs/<spec>.json
+```
+
+There is no test suite, linter, or package manifest. The site has no build
+step — opening any `.html` file in a browser is the local preview.
+
+## Key conventions
+
+- **New infographic = new HTML file** in the matching category folder, kebab-
+  case filename (e.g. `sql-migration-guide.html`), fully self-contained (no
+  external CSS / JS / image refs). The manifest, meta, favicon, tracking, and
+  back button are all added automatically post-merge — do not pre-populate them
+  in the PR.
+- **Don't add `<meta name="description">`, OG tags, favicon `<link>`, the Umami
+  script, or the floating back button manually.** The `ensure-*` scripts own
+  those regions and will refuse to touch already-marked blocks. Hand-written
+  versions without the marker can cause double-injection.
+- **Terminology rules** live in `scripts/terminology.json` with a `severity`
+  field. `high` (e.g. Azure AD → Entra ID, Cognitive Services → Azure AI
+  Services, Form Recognizer → Document Intelligence) is safe to `--apply`;
+  `low` / `medium` are report-only by default and need human review.
+- **Page freshness** is tracked via a `smec:last-accuracy-check` meta tag
+  stamped by `scripts/stamp-accuracy-date.py`. The weekly accuracy-review
+  workflow flags pages older than 28 days.
+- **Redirect stubs** (pages whose entire job is `<meta http-equiv="refresh">`)
+  are intentionally excluded from every chrome script — preserve that pattern
+  if you add one.
+- **Don't depend on a static-site generator, framework, or package manager.**
+  Plain HTML + Python stdlib scripts is a deliberate constraint
+  (`docs/automated-page-updates.md`, "Out of scope").
+
+## Workflows / Copilot agent integration
+
+- `ensure-site-chrome.yml` — post-merge on `main`, runs all `ensure-*` scripts +
+  `generate-manifest.py` in one sequential commit (avoids push races).
+- `fix-site-chrome-pr.yml` — same sequence on same-repo PRs, commits into the
+  PR branch.
+- `audit-site.yml` — PR, `continue-on-error: true`, uploads `reports/*.json` as
+  an artifact. Not a required check.
+- `copilot-page-review.yml` (monthly) and `accuracy-review.yml` (weekly,
+  Thursdays) — turn audit JSON into one issue per stale page and assign the
+  Copilot coding agent.
+
+**Important:** assignments made under `GITHUB_TOKEN` (i.e.
+`github-actions[bot]`) do **not** start the Copilot coding agent. These two
+workflows look for a `COPILOT_ASSIGN_TOKEN` secret (fine-grained PAT with
+`issues: write`, `contents: read`, `metadata: read`) and, if absent,
+**intentionally leave issues unassigned** rather than silently failing to
+trigger the agent. Don't "fix" this by falling back to `GITHUB_TOKEN` for the
+assignment step.
+
+The two review workflows cross-deduplicate by label (`accuracy-review`,
+`copilot-review`) and by an HTML marker comment in the issue body
+(`<!-- copilot-accuracy-review v1 -->`, `<!-- copilot-page-review v1 -->`,
+plus `<!-- page: <path> -->`). Preserve those markers if you edit the
+generators.
+
+## Contributor flow (don't break this)
+
+The published contributor path is **fork → upload HTML through the GitHub web
+UI → open PR** (`docs/adding-an-infographic-to-the-website.md`). No CLI
+required. Changes that would force contributors to clone, run scripts, or
+install tooling locally are out of scope for this repo.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,6 +80,12 @@ step — opening any `.html` file in a browser is the local preview.
   field. `high` (e.g. Azure AD → Entra ID, Cognitive Services → Azure AI
   Services, Form Recognizer → Document Intelligence) is safe to `--apply`;
   `low` / `medium` are report-only by default and need human review.
+  Per-page exception: wrap an intentional use of a deprecated term inline
+  with `<!-- smec-keep-term -->...<!-- /smec-keep-term -->` to exempt it
+  from both `--check` and `--apply` (e.g. on pages that teach a rename).
+  Don't nest the marker inside another HTML comment — the outer comment
+  will terminate at the first `-->`. Exempted matches are still recorded
+  under the report's top-level `exempted` map.
 - **Page freshness** is tracked via a `smec:last-accuracy-check` meta tag
   stamped by `scripts/stamp-accuracy-date.py`. The weekly accuracy-review
   workflow flags pages older than 28 days.

--- a/docs/automated-page-updates.md
+++ b/docs/automated-page-updates.md
@@ -114,7 +114,14 @@ Findings from each phase are appended below as the spike progresses.
   rules ship at `severity: low` or `medium` and require review; the
   high-severity ones — Azure AD → Entra ID, Cognitive Services → Azure
   AI Services, Form Recognizer → Document Intelligence — are safe to
-  `--apply` when they appear).
+  `--apply` when they appear). Pages that legitimately need the legacy
+  term (e.g. a decision guide explaining the rename) can wrap the
+  occurrence inline with
+  `<!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term -->`
+  to exempt it from both `--check` and `--apply`. Exempted matches are
+  still surfaced in `reports/deprecated-terms.json` under a top-level
+  `exempted` map so the bypass list stays auditable; unmatched
+  open/close markers fail `--check`.
 - Composing the content of any bulk-templating spec before applying it.
 
 ### Workflows

--- a/foundry/microsoft-ai-decision-guide.html
+++ b/foundry/microsoft-ai-decision-guide.html
@@ -721,20 +721,20 @@
         </div>
       </div>
 
-      <!-- 3 · Azure OpenAI Service -->
+      <!-- 3 · OpenAI platform card -->
       <div class="plat-card openai-card reveal" data-tags="api pro-code">
         <div class="plat-hdr openai-bg">
           <div class="plat-icon">
             <svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/><path d="M2 17l10 5 10-5" fill="none" stroke="#fff" stroke-width="1.5"/><path d="M2 12l10 5 10-5" fill="none" stroke="#fff" stroke-width="1.5"/></svg>
           </div>
-          <h3>Azure OpenAI Service <span class="new-badge-card">Updated</span></h3>
+          <h3><!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term --> <span class="new-badge-card">Updated</span></h3>
           <div class="subtitle">Enterprise API access to GPT-5.5, GPT-5.2, Realtime, Audio &amp; Image models</div>
           <a href="https://azure.microsoft.com/en-us/products/ai-services/openai-service/" target="_blank" class="plat-link"><svg viewBox="0 0 24 24"><path d="M14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/><path d="M5 5v14h14v-7h-2v5H7V7h5V5H5z"/></svg>Learn more</a>
         </div>
         <div class="plat-body">
           <div class="migration-note">
             <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
-            <div><strong>Migration recommended:</strong> Azure OpenAI Service remains fully available, but Microsoft highly recommends migrating to <a href="https://azure.microsoft.com/en-us/products/ai-foundry/" target="_blank">Microsoft Foundry</a> for a unified AI development experience. You can upgrade your existing Azure OpenAI resource to a Foundry resource while preserving your endpoint, API keys, and existing state.</div>
+            <div><strong>Migration recommended:</strong> <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term --> remains fully available, but Microsoft highly recommends migrating to <a href="https://azure.microsoft.com/en-us/products/ai-foundry/" target="_blank">Microsoft Foundry</a> for a unified AI development experience. You can upgrade your existing Azure OpenAI resource to a Foundry resource while preserving your endpoint, API keys, and existing state.</div>
           </div>
           <h4 class="openai-a">What It Is</h4>
           <ul>
@@ -1048,10 +1048,10 @@
         <button class="dt-restart" onclick="dtReset()">&#x21bb; Start Over</button>
       </div>
       <div class="dt-result openai-r dt-hidden" id="r-openai">
-        <h4>&#x2192; Azure OpenAI Service</h4>
+        <h4>&#x2192; <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term --></h4>
         <p>Direct API access to GPT-5.5, GPT-5.2, Realtime-1.5 voice, GPT-image-1.5, and Codex Max with Azure's enterprise security. Ideal for developers building LLM-powered, voice-enabled, or multimodal AI apps.</p>
-        <p style="margin-top:.75rem;padding:.6rem;background:rgba(193,154,0,.1);border-radius:8px;font-size:.85rem;"><strong>&#x26A0; Recommendation:</strong> Azure OpenAI Service is fully available, but Microsoft highly recommends migrating to <a href="https://azure.microsoft.com/en-us/products/ai-foundry/" target="_blank" style="font-weight:600;">Microsoft Foundry</a> for a unified AI development experience. Existing endpoints and API keys are preserved during migration.</p>
-        <p style="margin-top:.5rem;"><a href="https://azure.microsoft.com/en-us/products/ai-services/openai-service/" target="_blank" style="font-weight:600;">Explore Azure OpenAI Service &rarr;</a></p>
+        <p style="margin-top:.75rem;padding:.6rem;background:rgba(193,154,0,.1);border-radius:8px;font-size:.85rem;"><strong>&#x26A0; Recommendation:</strong> <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term --> is fully available, but Microsoft highly recommends migrating to <a href="https://azure.microsoft.com/en-us/products/ai-foundry/" target="_blank" style="font-weight:600;">Microsoft Foundry</a> for a unified AI development experience. Existing endpoints and API keys are preserved during migration.</p>
+        <p style="margin-top:.5rem;"><a href="https://azure.microsoft.com/en-us/products/ai-services/openai-service/" target="_blank" style="font-weight:600;">Explore <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term --> &rarr;</a></p>
         <button class="dt-restart" onclick="dtReset()">&#x21bb; Start Over</button>
       </div>
       <div class="dt-result foundry-r dt-hidden" id="r-foundry">

--- a/scripts/check-deprecated-terms.py
+++ b/scripts/check-deprecated-terms.py
@@ -8,6 +8,18 @@ the second run. Rules skip matches that are already adjacent to their
 replacement (e.g. "Microsoft Entra ID (previously Azure Active
 Directory)" is left alone).
 
+Per-page exceptions:
+    Wrap any intentional use of a deprecated term with the inline marker
+    pair to exempt it from both --check failures and --apply rewrites:
+
+        <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term -->
+
+    Use this when the page is teaching a rename, comparing the old and
+    new names, or otherwise needs the legacy term to read correctly.
+    Exempted matches are still recorded in the JSON report under the
+    top-level "exempted" key so reviewers can audit them. Unmatched
+    open/close markers fail --check.
+
 Modes:
     python3 scripts/check-deprecated-terms.py
         # report only; exits 0. Writes reports/deprecated-terms.json
@@ -45,6 +57,49 @@ META_REFRESH_RE = re.compile(
 )
 SKIP_DIRS = {".git", "node_modules", ".github", "reports"}
 SEVERITY_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+# Per-page inline exception markers. Authors wrap a span where a deprecated
+# term is intentional (e.g. when the page is teaching the rename) with:
+#
+#     <!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term -->
+#
+# Any rule match whose [start, end) is fully contained inside one of these
+# blocks is exempted from --check failures and from --apply rewrites. The
+# exemption is recorded separately in the JSON report under "exempted" so
+# reviewers can audit what's been intentionally bypassed.
+#
+# Nesting is NOT supported. Rule-id targeting is intentionally NOT supported
+# in v1 — keep the marker minimal.
+KEEP_TERM_OPEN_RE = re.compile(r"<!--\s*smec-keep-term\s*-->", re.IGNORECASE)
+KEEP_TERM_CLOSE_RE = re.compile(r"<!--\s*/\s*smec-keep-term\s*-->", re.IGNORECASE)
+KEEP_TERM_BLOCK_RE = re.compile(
+    r"<!--\s*smec-keep-term\s*-->.*?<!--\s*/\s*smec-keep-term\s*-->",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def find_keep_term_spans(content: str) -> list[tuple[int, int]]:
+    """Return [(start, end), ...] for every well-formed keep-term block.
+    The whole marker pair (including comments) is treated as protected."""
+    return [(m.start(), m.end()) for m in KEEP_TERM_BLOCK_RE.finditer(content)]
+
+
+def find_malformed_keep_terms(content: str) -> tuple[int, int]:
+    """Return (unmatched_open_count, unmatched_close_count) — anything not
+    swallowed by KEEP_TERM_BLOCK_RE."""
+    consumed: list[tuple[int, int]] = find_keep_term_spans(content)
+
+    def _outside(idx: int) -> bool:
+        return not any(s <= idx < e for s, e in consumed)
+
+    opens = sum(1 for m in KEEP_TERM_OPEN_RE.finditer(content) if _outside(m.start()))
+    closes = sum(1 for m in KEEP_TERM_CLOSE_RE.finditer(content) if _outside(m.start()))
+    return opens, closes
+
+
+def is_in_keep_term(match: re.Match, keep_spans: list[tuple[int, int]]) -> bool:
+    """True iff the match is fully contained inside a keep-term block."""
+    return any(s <= match.start() and match.end() <= e for s, e in keep_spans)
 
 
 def load_rules() -> list[dict[str, Any]]:
@@ -84,31 +139,41 @@ def is_already_fixed(content: str, match: re.Match, replacement: str) -> bool:
     return False
 
 
-def scan_file(path: str, rules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def scan_file(
+    path: str, rules: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], tuple[int, int]]:
+    """Returns (hits, exempted, (unmatched_open, unmatched_close))."""
     with open(path, encoding="utf-8", errors="replace") as fh:
         content = fh.read()
 
     if META_REFRESH_RE.search(content):
-        return []
+        return [], [], (0, 0)
+
+    keep_spans = find_keep_term_spans(content)
+    malformed = find_malformed_keep_terms(content)
 
     hits: list[dict[str, Any]] = []
+    exempted: list[dict[str, Any]] = []
     for rule in rules:
         for m in rule["compiled"].finditer(content):
             if is_already_fixed(content, m, rule["replacement"]):
                 continue
             line = content.count("\n", 0, m.start()) + 1
-            hits.append(
-                {
-                    "rule_id": rule["id"],
-                    "pattern": rule["pattern"],
-                    "match": m.group(0),
-                    "replacement": rule["replacement"],
-                    "severity": rule.get("severity", "medium"),
-                    "line": line,
-                    "span": [m.start(), m.end()],
-                }
-            )
-    return hits
+            entry = {
+                "rule_id": rule["id"],
+                "pattern": rule["pattern"],
+                "match": m.group(0),
+                "replacement": rule["replacement"],
+                "severity": rule.get("severity", "medium"),
+                "line": line,
+                "span": [m.start(), m.end()],
+            }
+            if is_in_keep_term(m, keep_spans):
+                entry["reason"] = "smec-keep-term"
+                exempted.append(entry)
+            else:
+                hits.append(entry)
+    return hits, exempted, malformed
 
 
 def apply_fixes(
@@ -126,10 +191,16 @@ def apply_fixes(
         pattern: re.Pattern[str] = rule["compiled"]
         replacement: str = rule["replacement"]
 
+        # Recompute keep-term spans before each rule because earlier rules
+        # may have rewritten content and shifted offsets.
+        keep_spans = find_keep_term_spans(content)
+
         # Walk matches right-to-left so indices stay valid across edits.
         matches = list(pattern.finditer(content))
         for m in reversed(matches):
             if is_already_fixed(content, m, replacement):
+                continue
+            if is_in_keep_term(m, keep_spans):
                 continue
             content = content[: m.start()] + replacement + content[m.end():]
             total += 1
@@ -189,12 +260,14 @@ def main() -> int:
     files = iter_html_files()
     min_sev = SEVERITY_ORDER[args.min_severity]
 
-    report: dict[str, Any] = {"files": {}, "summary": {}}
+    report: dict[str, Any] = {"files": {}, "exempted": {}, "summary": {}}
+    malformed_files: list[dict[str, Any]] = []
     total_hits = 0
+    total_exempted = 0
     total_applied = 0
 
     for path in files:
-        hits = scan_file(path, rules)
+        hits, exempted, malformed = scan_file(path, rules)
         rel = os.path.relpath(path, REPO_ROOT).replace("\\", "/")
         if args.apply:
             applied = apply_fixes(path, rules, min_sev)
@@ -202,15 +275,30 @@ def main() -> int:
             # Re-scan post-apply so the report reflects remaining issues
             # (should be zero for rules at/above the severity threshold
             # if our is_already_fixed guard is correct).
-            hits = scan_file(path, rules)
+            hits, exempted, malformed = scan_file(path, rules)
         if hits:
             report["files"][rel] = hits
             total_hits += len(hits)
+        if exempted:
+            report["exempted"][rel] = exempted
+            total_exempted += len(exempted)
+        unmatched_open, unmatched_close = malformed
+        if unmatched_open or unmatched_close:
+            malformed_files.append(
+                {
+                    "path": rel,
+                    "unmatched_open": unmatched_open,
+                    "unmatched_close": unmatched_close,
+                }
+            )
 
     report["summary"] = {
         "files_scanned": len(files),
         "files_with_hits": len(report["files"]),
         "total_hits": total_hits,
+        "files_with_exemptions": len(report["exempted"]),
+        "exempted_hits": total_exempted,
+        "malformed_keep_term_files": malformed_files,
         "total_applied": total_applied,
         "mode": "apply" if args.apply else ("check" if args.check else "report"),
         "min_severity_for_apply": args.min_severity,
@@ -232,11 +320,23 @@ def main() -> int:
         f"{summary['files_with_hits']}/{summary['files_scanned']} file(s). "
         f"mode={summary['mode']}. report={out_path}"
     )
+    if total_exempted:
+        print(
+            f"  {total_exempted} exempted hit(s) across "
+            f"{summary['files_with_exemptions']} file(s) "
+            f"(smec-keep-term)."
+        )
     if args.apply and total_applied:
         print(f"  applied {total_applied} replacement(s).")
+    if malformed_files:
+        print(
+            f"::warning::{len(malformed_files)} file(s) have unmatched "
+            f"smec-keep-term markers; see report."
+        )
 
-    if args.check and total_hits:
-        print("::warning::Deprecated terminology found. See report.")
+    if args.check and (total_hits or malformed_files):
+        if total_hits:
+            print("::warning::Deprecated terminology found. See report.")
         return 1
     return 0
 

--- a/scripts/terminology.json
+++ b/scripts/terminology.json
@@ -3,7 +3,8 @@
   "version": 1,
   "_warnings": [
     "Running `check-deprecated-terms.py --apply` applies rules in order. Cascading edits can produce awkward output: e.g. 'Azure Active Directory (Azure AD)' becomes 'Microsoft Entra ID (Microsoft Entra ID)' after both AAD rules fire. Review apply output before committing.",
-    "Rules at severity=low require human judgement; they are listed for awareness but should usually be reviewed in context before `--apply`."
+    "Rules at severity=low require human judgement; they are listed for awareness but should usually be reviewed in context before `--apply`.",
+    "Per-page exception: wrap an intentional use of a deprecated term inline with `<!-- smec-keep-term -->...<!-- /smec-keep-term -->` to exempt it from both --check and --apply. Use this for pages that teach a rename or otherwise need the legacy term verbatim. Do NOT nest the marker inside another HTML comment (the outer comment will terminate early). Exempted matches are still listed under the report's top-level `exempted` map for audit."
   ],
   "rules": [
     {


### PR DESCRIPTION
Adds a per-page exception mechanism to the deprecated-terminology checker so pages that intentionally use a deprecated term (e.g. when the page is teaching a rename) can opt out without disabling the rule globally.

## The mechanism

Wrap any intentional occurrence inline:

```html
<!-- smec-keep-term -->Azure OpenAI Service<!-- /smec-keep-term -->
```

Matches whose `[start, end)` is fully contained inside a well-formed marker pair are exempted from both `--check` failures and `--apply` rewrites. Exempted matches are still recorded under a new top-level `exempted` map in `reports/deprecated-terms.json` so the bypass list stays auditable. Unmatched open/close markers are reported under `summary.malformed_keep_term_files` and fail `--check`.

The existing `files` shape in the report is unchanged, so `audit-site-comment.yml` and `open-copilot-review-issues.py` keep working without modification.

## Implementation notes

- Full-containment semantics (not overlap) — keeps accidental partial wraps from silently suppressing real matches.
- Keep-spans are recomputed inside `apply_fixes` before each rule, since earlier rules mutate `content` and would otherwise stale-out the offsets.
- v1 deliberately does **not** support nesting or rule-id targeting (`smec-keep-term: <rule-id>`). Add later if needed.
- Don't nest the marker inside another HTML comment — the outer `-->` would terminate early and leak the term as visible text. Documented in `terminology.json`, `docs/automated-page-updates.md`, and `.github/copilot-instructions.md`.

## Real fix in this PR

Closes #65 and supersedes #66 — both were about the six `Azure OpenAI Service` occurrences in `foundry/microsoft-ai-decision-guide.html`, which are intentional (the page is teaching users to migrate to Foundry). Five user-visible occurrences are now wrapped with the marker; the sixth was a developer-only HTML section comment (`<!-- 3 · Azure OpenAI Service -->`) which has been rephrased rather than wrapped, since nesting HTML comments is invalid.

## Verified

- Baseline before marker: 6 hits in 1 file.
- After marker: 0 hits, 5 exempted, `--check` exits 0.
- `--apply` and re-`--apply` are both no-ops (idempotent).
- Also adds `.github/copilot-instructions.md` documenting the repo's chrome-script contract and conventions for future Copilot sessions.