### PR TITLE
fix(back-button): always show `Back` label, expand to full text on hover

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Every chrome script follows the same contract (see
 1. **Idempotent** — running twice is a no-op the second time.
 2. Carries a **version marker** the script greps for to detect prior injections,
    e.g. `<!-- smec-meta v1 -->`, `<!-- smec-favicon v1 -->`,
-   `data-smec-back-button="v1"`, `data-website-id=<umami-id>`,
+   `data-smec-back-button="v2"`, `data-website-id=<umami-id>`,
    `<!-- smec-tmpl:<id> -->` for bulk templating.
 3. Supports `--check` (exits non-zero if any file is missing the expected
    state, modifies nothing) — this is what CI calls.

--- a/app-platform-services/apim-logic-apps-functions-decision-guide.html
+++ b/app-platform-services/apim-logic-apps-functions-decision-guide.html
@@ -610,72 +610,6 @@
     }
   </style>
   <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="App Platform Services Decision Guide — APIM, Logic Apps, Functions | SME&amp;C — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="App Platform Services Decision Guide — APIM, Logic Apps, Functions | SME&amp;C">
@@ -689,10 +623,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ═══════════════════════════════════════════════════
      SECTION 1 — HERO

--- a/app-platform-services/azure-apim-v2-networking-guide.html
+++ b/app-platform-services/azure-apim-v2-networking-guide.html
@@ -505,72 +505,6 @@ section{padding:80px 20px}
 .reveal.visible{opacity:1;transform:translateY(0)}
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure API Management v2 — Public &amp; Private Networking Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Azure API Management v2 — Public &amp; Private Networking Guide">
@@ -584,10 +518,65 @@ section{padding:80px 20px}
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-05-07">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- HERO -->
 <header class="hero">

--- a/app-platform-services/azure-communication-services-guide.html
+++ b/app-platform-services/azure-communication-services-guide.html
@@ -1472,72 +1472,6 @@
 
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure Communication Services — The future of customer communication — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Azure Communication Services — The future of customer communication">
@@ -1551,10 +1485,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-27">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div id="scrollProgress"></div>
 

--- a/avd/healthcare-vdi-strategyguide.html
+++ b/avd/healthcare-vdi-strategyguide.html
@@ -603,72 +603,6 @@ footer a:hover{text-decoration:underline}
 }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Healthcare VDI Strategy — Windows 365 + Azure Virtual Desktop — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Healthcare VDI Strategy — Windows 365 + Azure Virtual Desktop">
@@ -682,10 +616,65 @@ footer a:hover{text-decoration:underline}
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- Scroll Progress -->
 <div class="scroll-progress" id="scrollProgress"></div>

--- a/azure-databases/azure-sql-comparison.html
+++ b/azure-databases/azure-sql-comparison.html
@@ -530,72 +530,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure SQL Decision Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Azure SQL Decision Guide">
@@ -609,10 +543,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div class="container">
 

--- a/azure-databases/azure-sql-db-bcdr.html
+++ b/azure-databases/azure-sql-db-bcdr.html
@@ -1171,72 +1171,6 @@ footer p { font-size: 14px; margin-bottom: 20px; max-width: 600px; margin-left: 
 }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure SQL Database: Business Continuity &amp; Disaster Recovery — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Azure SQL Database: Business Continuity &amp; Disaster Recovery">
@@ -1250,10 +1184,65 @@ footer p { font-size: 14px; margin-bottom: 20px; max-width: 600px; margin-left: 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- NAV -->
 <nav class="nav">

--- a/azure-databases/sql-2016-eol-customer-guide.html
+++ b/azure-databases/sql-2016-eol-customer-guide.html
@@ -227,72 +227,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="SQL Server 2016 End of Support — Your Complete Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="SQL Server 2016 End of Support — Your Complete Guide">
@@ -306,10 +240,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- Nav -->
 <nav class="nav" id="nav">

--- a/defender-for-cloud/defender-for-cloud-unified-security.html
+++ b/defender-for-cloud/defender-for-cloud-unified-security.html
@@ -1423,72 +1423,6 @@ footer a:hover { text-decoration: underline; }
 }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Microsoft Defender for Cloud · Interactive Learning — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Microsoft Defender for Cloud · Interactive Learning">
@@ -1502,10 +1436,65 @@ footer a:hover { text-decoration: underline; }
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-27">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ========== NAV ========== -->
 <nav class="nav">

--- a/docs/automated-page-updates.md
+++ b/docs/automated-page-updates.md
@@ -96,7 +96,7 @@ Findings from each phase are appended below as the spike progresses.
 | `scripts/check-links.py` | HEAD/GET every external http(s) link → `reports/link-health.json` | n/a |
 | `scripts/check-deprecated-terms.py` | Scan / optionally rewrite terms from `terminology.json` | n/a |
 | `scripts/ensure-tracking.py` (existing) | Inject Umami analytics snippet | `data-website-id=...` |
-| `scripts/ensure-back-button.py` (existing) | Inject floating back button | `data-smec-back-button="v1"` |
+| `scripts/ensure-back-button.py` (existing) | Inject floating back button | `data-smec-back-button="v2"` |
 | `scripts/ensure-meta.py` | Inject description / OG / Twitter tags | `<!-- smec-meta v1 -->` |
 | `scripts/ensure-favicon.py` | Inject favicon `<link>` pointing at `/favicon.svg` | `<!-- smec-favicon v1 -->` |
 | `scripts/ensure-a11y.py` | Read-only a11y report → `reports/a11y.json` | n/a |

--- a/events/azure-events-may-2026.html
+++ b/events/azure-events-may-2026.html
@@ -221,72 +221,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta property="og:title" content="Azure Upcoming Events — Webinars &amp; Hands-on Labs | May-June 2026">
 <meta property="og:description" content="Azure Upcoming Events — Webinars &amp; Hands-on Labs | May-June 2026 — an interactive infographic from the SME&amp;C Infographic Hub.">
@@ -299,10 +233,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-content">

--- a/fabric/fabric-data-agent-best-practices.html
+++ b/fabric/fabric-data-agent-best-practices.html
@@ -254,72 +254,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Fabric Data Agent — Modeling Best Practices — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Fabric Data Agent — Modeling Best Practices">
@@ -333,10 +267,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ═══════════════════ HERO ═══════════════════ -->
 <header class="hero">

--- a/fabric/fabric-governance-infographic.html
+++ b/fabric/fabric-governance-infographic.html
@@ -344,72 +344,6 @@
   }
   @media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
 </style>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Microsoft Fabric Governance Framework — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Microsoft Fabric Governance Framework">
@@ -423,10 +357,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ═══════════════════ HERO ═══════════════════ -->
 <header class="hero">

--- a/fabric/medallion-architecture-infographic.html
+++ b/fabric/medallion-architecture-infographic.html
@@ -932,72 +932,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Medallion Lakehouse Architecture in Microsoft Fabric — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Medallion Lakehouse Architecture in Microsoft Fabric">
@@ -1011,10 +945,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ===== HERO ===== -->
 <div class="hero">

--- a/fabric/microsoft-fabric-interactive.html
+++ b/fabric/microsoft-fabric-interactive.html
@@ -469,72 +469,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Microsoft Fabric — Unified Analytics Platform — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Microsoft Fabric — Unified Analytics Platform">
@@ -548,10 +482,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-23">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div class="bg-particles"></div>
 

--- a/foundry/00-microsoft-stack-overview.html
+++ b/foundry/00-microsoft-stack-overview.html
@@ -474,67 +474,57 @@
 <meta name="twitter:description" content="The Microsoft App, AI &amp; Data Stack — A Top-to-Bottom Map — an interactive entry-point infographic from the SME&amp;C Infographic Hub.">
 <!-- smec-favicon v1 -->
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<style>/* smec-back-btn v1 */
+<style>/* smec-back-btn v2 */
 .smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
   opacity: 0;
   animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
   transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
   transition:
     opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
 
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
 .smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
 .smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
   max-width: 260px; opacity: 1;
   transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
 
 @keyframes smec-back-btn-in {
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 @media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
     transition: background 0.2s ease, color 0.2s ease;
     animation: none; opacity: 1; }
 }
@@ -542,7 +532,7 @@
 </style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div class="progress" id="progress"></div>
 

--- a/foundry/ai-agent-anatomy.html
+++ b/foundry/ai-agent-anatomy.html
@@ -292,68 +292,6 @@
     .component-card:hover, .ms-card:hover, .hero-cta:hover, .learn-link:hover { transform: none; }
   }
 </style>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <meta name="description" content="The Anatomy of an AI Agent — A Field Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="The Anatomy of an AI Agent — A Field Guide">
@@ -366,12 +304,67 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta name="smec:last-accuracy-check" content="2026-05-14">
 <!-- smec-meta v1 -->
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
+
 <a class="skip-link" href="#main">Skip to main content</a>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
-
 <div class="progress" id="progress" aria-hidden="true"></div>
 
 <nav class="top" aria-label="Section navigation">

--- a/foundry/ai-gateway-apim.html
+++ b/foundry/ai-gateway-apim.html
@@ -553,72 +553,6 @@
     .hero h1 { font-size: 2.2rem; }
   }
 </style>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <!-- smec-meta v1 -->
 <meta name="description" content="AI Gateway in Azure API Management — One Front Door for Every Model — an interactive infographic from the SME&amp;C Infographic Hub.">
@@ -633,10 +567,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-05-14">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div class="progress" id="progress"></div>
 

--- a/foundry/ai-landing-zones.html
+++ b/foundry/ai-landing-zones.html
@@ -633,72 +633,6 @@
     .hero h1 { font-size: 2.2rem; }
   }
 </style>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure AI Landing Zones — The Runway Before Takeoff — an interactive infographic from the SME&amp;C Infographic Hub.">
@@ -713,10 +647,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-05-14">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <div class="progress" id="progress"></div>
 

--- a/foundry/frontier-firm-playbook.html
+++ b/foundry/frontier-firm-playbook.html
@@ -470,72 +470,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Become a Frontier Firm — Microsoft&#x27;s Playbook for the Agentic Enterprise — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Become a Frontier Firm — Microsoft&#x27;s Playbook for the Agentic Enterprise">
@@ -549,10 +483,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-05-14">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- NAV -->
 <nav class="nav" id="nav">

--- a/foundry/microsoft-ai-decision-guide.html
+++ b/foundry/microsoft-ai-decision-guide.html
@@ -476,72 +476,6 @@
   }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Microsoft AI Platform Decision Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Microsoft AI Platform Decision Guide">
@@ -553,10 +487,65 @@
 <meta name="twitter:description" content="Microsoft AI Platform Decision Guide — an interactive infographic from the SME&amp;C Infographic Hub.">
 <!-- smec-favicon v1 -->
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- NAV -->
 <nav class="nav" id="nav">

--- a/foundry/microsoft-iq-platforms-guide.html
+++ b/foundry/microsoft-iq-platforms-guide.html
@@ -515,72 +515,6 @@
     .hero { min-height: auto; padding: 3rem 2rem; }
   }
 </style>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
 <!-- smec-meta v1 -->
 <meta name="description" content="Microsoft IQ Platforms — Foundry IQ, Fabric IQ, Work IQ: The Knowledge Layer for Smarter Agents — an interactive infographic from the SME&amp;C Infographic Hub.">
@@ -595,10 +529,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-05-14">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- NAV -->
 <nav class="nav" id="nav">

--- a/github-copilot/agent-commit-identity.html
+++ b/github-copilot/agent-commit-identity.html
@@ -107,72 +107,6 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Who authored this PR? Agent identity on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Who authored this PR? Agent identity on GitHub">
@@ -186,10 +120,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-badge">

--- a/github-copilot/agent-correction-loop.html
+++ b/github-copilot/agent-correction-loop.html
@@ -121,72 +121,6 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="When the agent&#x27;s PR is wrong: the correction loop — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="When the agent&#x27;s PR is wrong: the correction loop">
@@ -200,10 +134,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-badge">

--- a/github-copilot/agent-governance-surface.html
+++ b/github-copilot/agent-governance-surface.html
@@ -103,72 +103,6 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Where does the agent&#x27;s audit trail live? — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Where does the agent&#x27;s audit trail live?">
@@ -182,10 +116,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-badge">

--- a/github-copilot/ai-agent-setup-cost.html
+++ b/github-copilot/ai-agent-setup-cost.html
@@ -228,72 +228,6 @@
   .section-flush-top { padding-top: 0; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Setup cost to first PR: AI coding agents on GitHub — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Setup cost to first PR: AI coding agents on GitHub">
@@ -307,10 +241,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <!-- ── Hero ───────────────────────────────────────── -->
 <header class="hero">

--- a/github-copilot/ai-coding-agent-landscape.html
+++ b/github-copilot/ai-coding-agent-landscape.html
@@ -91,72 +91,6 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Which AI coding agent fits which team? — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Which AI coding agent fits which team?">
@@ -170,10 +104,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-badge">

--- a/github-copilot/copilot-learn-mcp-dogfood.html
+++ b/github-copilot/copilot-learn-mcp-dogfood.html
@@ -95,72 +95,6 @@
   .sources-list li { margin-bottom: 6px; font-size: .82rem; }
 </style>
 <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Copilot + Microsoft Learn: how this site schedules accuracy work — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Copilot + Microsoft Learn: how this site schedules accuracy work">
@@ -174,10 +108,65 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-30">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
-
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
 <header class="hero">
   <div class="hero-badge">

--- a/infrastructure/azure-arc.html
+++ b/infrastructure/azure-arc.html
@@ -962,72 +962,6 @@
         }
     </style>
     <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="Azure Arc: The Multi-Cloud Command Center — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="Azure Arc: The Multi-Cloud Command Center">
@@ -1041,11 +975,67 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-27">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
-    <!-- Scroll Progress Bar -->
+<!-- Scroll Progress Bar -->
     <div class="scroll-progress" id="scrollProgress"></div>
 
     <!-- ========== TOP BAR ========== -->

--- a/link-builder.html
+++ b/link-builder.html
@@ -86,72 +86,6 @@
     .ok { color: #107C10; margin-top: 8px; }
   </style>
   <script defer src="https://a.ndme.sh/script.js" data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"></script>
-<style>/* smec-back-btn v1 */
-.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
-  opacity: 0;
-  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
-  overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
-  transition:
-    opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
-.smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
-.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
-  max-width: 260px; opacity: 1;
-  transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
-
-@keyframes smec-back-btn-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-@media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
-    transition: background 0.2s ease, color 0.2s ease;
-    animation: none; opacity: 1; }
-}
-@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
-</style>
 <!-- smec-meta v1 -->
 <meta name="description" content="UTM Link Builder | SME&amp;C Infographics — an interactive infographic from the SME&amp;C Infographic Hub.">
 <meta property="og:title" content="UTM Link Builder | SME&amp;C Infographics">
@@ -165,11 +99,67 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
 <meta name="smec:last-accuracy-check" content="2026-04-24">
+<style>/* smec-back-btn v2 */
+.smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
+  opacity: 0;
+  animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  transition:
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+  overflow: hidden; white-space: nowrap; }
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
+  transition:
+    opacity 0.18s ease 0s,
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
+
+.smec-back-btn:hover, .smec-back-btn:focus-visible {
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
+.smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
+  max-width: 260px; opacity: 1;
+  transition:
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
+
+@keyframes smec-back-btn-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (hover: none) {
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
+    transition: background 0.2s ease, color 0.2s ease;
+    animation: none; opacity: 1; }
+}
+@media (max-width: 600px) { .smec-back-btn { bottom: 12px; left: 12px; } }
+</style>
 </head>
 <body>
-<a href="/" class="smec-back-btn" data-smec-back-button="v1" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back to SME&amp;C Infographics</span></a>
+<a href="/" class="smec-back-btn" data-smec-back-button="v2" aria-label="Back to SME&amp;C Infographics"><svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg><span class="smec-back-btn__label">Back<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span></span></a>
 
-  <div class="wrap">
+<div class="wrap">
     <h1>UTM Link Builder</h1>
     <p class="lede">
       Generate a tracked link that routes through

--- a/scripts/audit-pages.py
+++ b/scripts/audit-pages.py
@@ -87,7 +87,7 @@ EOL_RE = re.compile(
 
 # Markers from existing chrome scripts.
 TRACKING_MARKER = 'data-website-id="9478c1a0-93c6-4c21-855a-69e50e15cbc4"'
-BACK_BUTTON_MARKER = 'data-smec-back-button="v1"'
+BACK_BUTTON_MARKER = 'data-smec-back-button="v2"'
 
 
 def _read(path: str) -> str:

--- a/scripts/check-accuracy-staleness.py
+++ b/scripts/check-accuracy-staleness.py
@@ -254,7 +254,7 @@ def _render(rel: str, title: str, last_check: dt.date | None,
     )
     parts.append(
         "- Preserve all idempotency markers verbatim: "
-        "`data-website-id=...`, `data-smec-back-button=\"v1\"`, "
+        "`data-website-id=...`, `data-smec-back-button=\"v2\"`, "
         "`<!-- smec-meta v1 -->`, `<!-- smec-favicon v1 -->`, "
         "`<!-- smec-tmpl:<id> -->`."
     )

--- a/scripts/ensure-back-button.py
+++ b/scripts/ensure-back-button.py
@@ -5,9 +5,9 @@ every HTML infographic page. The button links to the library landing
 page ("/") so users who arrive directly on an infographic can return
 to the index.
 
-Collapsed, the button is a small circular icon in the top-left corner;
-on hover, focus, or on coarse-pointer (touch) devices it expands to
-reveal the label "Back to SME&C Infographics".
+Collapsed, the button is a small pill in the bottom-left corner that
+reads "Back". On hover, focus, or on coarse-pointer (touch) devices it
+expands to reveal the full label "Back to SME&C Infographics".
 
 Idempotent: if the button is already present (detected by a unique
 anchor + style marker pair) the file is left unchanged. Redirect stubs
@@ -32,71 +32,74 @@ import sys
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROOT_INDEX = os.path.join(REPO_ROOT, "index.html")
 
-MARKER = 'data-smec-back-button="v1"'
-STYLE_MARKER = "/* smec-back-btn v1 */"
+MARKER = 'data-smec-back-button="v2"'
+STYLE_MARKER = "/* smec-back-btn v2 */"
+
+# Legacy v1 markers — when found, the v1 style block and anchor are
+# stripped so the current v2 versions can replace them cleanly.
+OLD_STYLE_MARKER = "/* smec-back-btn v1 */"
+OLD_ANCHOR_RE = re.compile(
+    r'[ \t]*<a\b[^>]*\bdata-smec-back-button\s*=\s*["\']v1["\'][^>]*>'
+    r'.*?</a>\s*\r?\n?',
+    re.IGNORECASE | re.DOTALL,
+)
+OLD_STYLE_RE = re.compile(
+    r'[ \t]*<style>\s*/\*\s*smec-back-btn v1\s*\*/.*?</style>\s*\r?\n?',
+    re.IGNORECASE | re.DOTALL,
+)
 
 BACK_BUTTON_STYLE = (
     "<style>" + STYLE_MARKER + """
 .smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: 0; min-width: 44px; height: 44px; padding: 0; border-radius: 22px;
-  background: rgba(0, 120, 212, 0.92); color: #fff; text-decoration: none;
-  font: 600 13px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: flex-start;
+  gap: 8px; height: 40px; padding: 0 16px 0 12px; border-radius: 20px;
+  background: rgba(0, 120, 212, 0.92) !important; color: #fff !important;
+  text-decoration: none !important;
+  font: 600 14px/1 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  letter-spacing: 0.01em;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18); backdrop-filter: blur(6px);
   opacity: 0;
   animation: smec-back-btn-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
-  /* Collapsing: wait for the label to fade out, then shrink the pill. */
   transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s;
+    padding 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    box-shadow 0.3s ease;
   overflow: hidden; white-space: nowrap; }
-.smec-back-btn__icon { flex: 0 0 auto;
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
-.smec-back-btn__label { max-width: 0; opacity: 0;
-  /* Collapsing: label fades out first, then its width collapses with the pill. */
+.smec-back-btn__icon { flex: 0 0 auto; display: inline-block;
+  width: 18px; height: 18px; }
+.smec-back-btn__label { display: inline-block; flex: 0 0 auto;
+  font: inherit; color: inherit; }
+.smec-back-btn__more { display: inline-block; max-width: 0; opacity: 0;
+  overflow: hidden; vertical-align: bottom;
+  font: inherit; color: inherit;
   transition:
     opacity 0.18s ease 0s,
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0.2s; }
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0.05s; }
 
-/* Expanding: pill and label grow together in one motion; text appears near the end. */
 .smec-back-btn:hover, .smec-back-btn:focus-visible {
-  gap: 10px; padding: 0 18px 0 12px;
-  background: rgba(0, 90, 158, 0.96); color: #fff; text-decoration: none;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
-  transition:
-    padding 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    gap 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    background 0.35s ease 0s,
-    box-shadow 0.35s ease 0s; }
+  background: rgba(0, 90, 158, 0.96) !important; color: #fff !important;
+  text-decoration: none !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22); }
 .smec-back-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
-.smec-back-btn:hover .smec-back-btn__icon,
-.smec-back-btn:focus-visible .smec-back-btn__icon {
-  transform: translateX(-2px);
-  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s; }
-.smec-back-btn:hover .smec-back-btn__label,
-.smec-back-btn:focus-visible .smec-back-btn__label {
+.smec-back-btn:hover .smec-back-btn__more,
+.smec-back-btn:focus-visible .smec-back-btn__more {
   max-width: 260px; opacity: 1;
   transition:
-    max-width 0.5s cubic-bezier(0.22, 1, 0.36, 1) 0s,
-    opacity 0.3s ease 0.3s; }
+    max-width 0.45s cubic-bezier(0.22, 1, 0.36, 1) 0s,
+    opacity 0.25s ease 0.2s; }
 
 @keyframes smec-back-btn-in {
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 @media (hover: none) {
-  .smec-back-btn { gap: 10px; padding: 0 18px 0 12px; }
-  .smec-back-btn__label { max-width: 260px; opacity: 1; }
+  .smec-back-btn__more { max-width: 260px; opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .smec-back-btn, .smec-back-btn__icon, .smec-back-btn__label,
-  .smec-back-btn:hover, .smec-back-btn:focus-visible,
-  .smec-back-btn:hover .smec-back-btn__icon,
-  .smec-back-btn:focus-visible .smec-back-btn__icon,
-  .smec-back-btn:hover .smec-back-btn__label,
-  .smec-back-btn:focus-visible .smec-back-btn__label {
+  .smec-back-btn, .smec-back-btn__more,
+  .smec-back-btn:hover .smec-back-btn__more,
+  .smec-back-btn:focus-visible .smec-back-btn__more {
     transition: background 0.2s ease, color 0.2s ease;
     animation: none; opacity: 1; }
 }
@@ -110,7 +113,9 @@ BACK_BUTTON_ANCHOR = (
     '<svg class="smec-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24"'
     ' width="18" height="18"><path fill="currentColor"'
     ' d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>'
-    '<span class="smec-back-btn__label">Back to SME&amp;C Infographics</span>'
+    '<span class="smec-back-btn__label">Back'
+    '<span class="smec-back-btn__more">&nbsp;to SME&amp;C Infographics</span>'
+    '</span>'
     '</a>'
 )
 
@@ -120,7 +125,7 @@ META_REFRESH_RE = re.compile(
     r'<meta\s+http-equiv=["\']refresh["\']', re.IGNORECASE
 )
 ANCHOR_RE = re.compile(
-    r'<a\b[^>]*\bdata-smec-back-button\s*=\s*["\']v1["\']', re.IGNORECASE
+    r'<a\b[^>]*\bdata-smec-back-button\s*=\s*["\']v2["\']', re.IGNORECASE
 )
 
 SKIP_DIRS = {".git", "node_modules", ".github"}
@@ -156,6 +161,11 @@ def ensure_button(filepath: str, check_only: bool = False) -> str:
     has_style = STYLE_MARKER in content
     if has_anchor and has_style:
         return "present"
+
+    # Strip any v1 leftovers before re-injecting the v2 button.
+    if OLD_STYLE_MARKER in content:
+        content = OLD_STYLE_RE.sub("", content)
+    content = OLD_ANCHOR_RE.sub("", content)
 
     head_match = HEAD_CLOSE_RE.search(content)
     if not head_match:

--- a/scripts/open-copilot-review-issues.py
+++ b/scripts/open-copilot-review-issues.py
@@ -158,7 +158,7 @@ def _render(rel: str,
     )
     parts.append(
         "- Preserve all idempotency markers verbatim: "
-        "`data-website-id=...`, `data-smec-back-button=\"v1\"`, "
+        "`data-website-id=...`, `data-smec-back-button=\"v2\"`, "
         "`<!-- smec-meta v1 -->`, `<!-- smec-favicon v1 -->`, "
         "`<!-- smec-tmpl:<id> -->`."
     )


### PR DESCRIPTION
## Problem

The v1 floating back button rendered as a 44px icon-only pill in the collapsed state. On some infographics, host-page CSS was overriding the label's collapsed `max-width: 0; opacity: 0` rules, causing a partial word (e.g. `Bac`) to leak through the pill. See the user-reported screenshot.

## Fix

Rebuild the button as a v2 component:

- **Collapsed (default):** small pill reading `← Back`.
- **Hover / focus / touch:** expands to `← Back to SME&C Infographics`.
- Critical color/text-decoration rules marked `!important` to defend against host-page `a {}` rules.

## Rollout

`scripts/ensure-back-button.py` now strips v1 style + anchor blocks before injecting v2, so the change rolls out cleanly to every infographic in one run.

Updated to look for the v2 marker:
- `scripts/audit-pages.py`
- `scripts/check-accuracy-staleness.py`
- `scripts/open-copilot-review-issues.py`
- `.github/copilot-instructions.md`
- `docs/automated-page-updates.md`

## Verified locally

```npython scripts/ensure-back-button.py          # added 26 pages
python scripts/ensure-back-button.py --check   # 0 missing, 28 present (idempotent)
python scripts/audit-pages.py                  # pages_missing_back_button: 0
```