### PR TITLE
Preserve original submitter for accuracy review workflow

### DIFF
--- a/.github/workflows/fix-site-chrome-pr.yml
+++ b/.github/workflows/fix-site-chrome-pr.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/ensure-meta.py"
       - "scripts/ensure-favicon.py"
       - "scripts/generate-manifest.py"
+      - "scripts/tag-submitter.py"
       - ".github/workflows/fix-site-chrome-pr.yml"
 
 permissions:
@@ -38,6 +39,28 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: Collect changed HTML files
+        id: changed
+        run: |
+          set -euo pipefail
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git diff --name-only --diff-filter=AM "origin/${{ github.base_ref }}"...HEAD \
+            | grep -E '\.html$' \
+            | sort -u \
+            > changed-html.txt || true
+          echo "Changed HTML files:"
+          cat changed-html.txt || true
+          if [ ! -s changed-html.txt ]; then
+            echo "no_html=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag original submitter on changed HTML pages
+        if: steps.changed.outputs.no_html != 'true'
+        env:
+          ORIGINAL_SUBMITTER: ${{ github.event.pull_request.user.login }}
+        run: |
+          xargs -r -a changed-html.txt python3 scripts/tag-submitter.py --submitter "$ORIGINAL_SUBMITTER"
 
       - name: Ensure tracking snippet in HTML pages
         run: python3 scripts/ensure-tracking.py

--- a/.github/workflows/tag-submitter-on-merge.yml
+++ b/.github/workflows/tag-submitter-on-merge.yml
@@ -1,0 +1,69 @@
+name: Tag Original Submitter on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tag-submitter-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  tag-submitter:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Collect changed HTML files
+        id: changed
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --paginate \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' \
+            | grep -E '\.html$' \
+            | sort -u \
+            > changed-html.txt || true
+          echo "Changed HTML files:"
+          cat changed-html.txt || true
+          if [ ! -s changed-html.txt ]; then
+            echo "no_html=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag original submitter on merged HTML pages
+        if: steps.changed.outputs.no_html != 'true'
+        env:
+          ORIGINAL_SUBMITTER: ${{ github.event.pull_request.user.login }}
+        run: |
+          xargs -r -a changed-html.txt python3 scripts/tag-submitter.py --submitter "$ORIGINAL_SUBMITTER"
+
+      - name: Commit any tagged pages
+        if: steps.changed.outputs.no_html != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A -- '*.html'
+          if git diff --staged --quiet; then
+            echo "No submitter tags to commit."
+          else
+            git commit -m "chore: tag original submitter on merged pages"
+            git push
+          fi

--- a/scripts/check-accuracy-staleness.py
+++ b/scripts/check-accuracy-staleness.py
@@ -45,10 +45,16 @@ OUT_DIR = os.path.join(REPORTS_DIR, "accuracy-review-issues")
 ISSUE_MARKER = "<!-- copilot-accuracy-review v1 -->"
 
 META_NAME = "smec:last-accuracy-check"
+SUBMITTER_NAME = "smec:submitter"
 META_BLOCK_MARKER = "<!-- smec-accuracy v1 -->"
-
+    
 ACCURACY_META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']' + re.escape(META_NAME)
+    + r'["\'][^>]*content=["\']([^"\']*)["\']',
+    re.IGNORECASE,
+)
+SUBMITTER_META_RE = re.compile(
+    r'<meta\s+[^>]*name=["\']' + re.escape(SUBMITTER_NAME)
     + r'["\'][^>]*content=["\']([^"\']*)["\']',
     re.IGNORECASE,
 )
@@ -77,6 +83,13 @@ def _extract_title(content: str, fallback: str) -> str:
         return fallback
     raw = re.sub(r"\s+", " ", m.group(1)).strip()
     return raw or fallback
+
+
+def _extract_submitter(content: str) -> str | None:
+    m = SUBMITTER_META_RE.search(content)
+    if not m:
+        return None
+    return m.group(1).strip() or None
 
 
 def _sanitize_title(title: str) -> str:
@@ -124,7 +137,8 @@ def _classify(filepath: str, today: dt.date,
 
 
 def _render(rel: str, title: str, last_check: dt.date | None,
-            age_days: int | None, max_age_days: int) -> str:
+            age_days: int | None, max_age_days: int,
+            submitter: str | None) -> str:
     safe_title = _sanitize_title(title)
     if last_check is None:
         freshness_line = (
@@ -154,6 +168,11 @@ def _render(rel: str, title: str, last_check: dt.date | None,
     parts.append(f"**Page title:** {safe_title}")
     parts.append(f"**File:** `{rel}`")
     parts.append(freshness_line)
+    if submitter:
+        parts.append(f"**Original submitter:** `@{submitter}`")
+        parts.append(f"**Reviewer to add on the draft PR:** `@{submitter}`")
+    else:
+        parts.append("**Original submitter:** _not recorded on page metadata._")
     parts.append("")
     parts.append("## What to do")
     parts.append("")
@@ -327,10 +346,10 @@ def main() -> int:
 
     only_prefix = args.only.rstrip("/") + "/" if args.only else None
 
-    eligible: list[tuple[str, str, dt.date | None, int | None]] = []
+    eligible: list[tuple[str, str, dt.date | None, int | None, str | None]] = []
     fresh_count = 0
     skipped_count = 0
-
+    
     for filepath in sorted(iter_html_files(REPO_ROOT)):
         rel = os.path.relpath(filepath, REPO_ROOT).replace(os.sep, "/")
         if only_prefix and not (rel + "/").startswith(only_prefix) and rel != args.only:
@@ -348,7 +367,8 @@ def main() -> int:
         title = _extract_title(
             content, os.path.splitext(os.path.basename(filepath))[0]
         )
-        eligible.append((rel, title, last, age))
+        submitter = _extract_submitter(content)
+        eligible.append((rel, title, last, age, submitter))
 
     os.makedirs(OUT_DIR, exist_ok=True)
     # Clean previous run so the index always matches what's on disk.
@@ -361,11 +381,11 @@ def main() -> int:
 
     index: list[dict[str, Any]] = []
     dropped_over_cap: list[str] = []
-    for rel, title, last, age in eligible:
+    for rel, title, last, age, submitter in eligible:
         if len(index) >= args.max_issues:
             dropped_over_cap.append(rel)
             continue
-        body = _render(rel, title, last, age, args.max_age_days)
+        body = _render(rel, title, last, age, args.max_age_days, submitter)
         slug = rel.replace("/", "__").replace(".html", "")
         out_path = os.path.join(OUT_DIR, f"{slug}.md")
         with open(out_path, "w", encoding="utf-8") as fh:

--- a/scripts/tag-submitter.py
+++ b/scripts/tag-submitter.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Stamp the original submitter on one or more HTML infographics.
+
+Each page gets an idempotent metadata block that records the GitHub login
+of the original contributor who added the page. The marker is injected just
+before `</head>` and the existing `smec:submitter` meta value is updated in
+place on subsequent runs.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROOT_INDEX = os.path.join(REPO_ROOT, "index.html")
+
+MARKER = "<!-- smec-submitter v1 -->"
+META_NAME = "smec:submitter"
+
+HEAD_CLOSE_RE = re.compile(r"(?P<indent>[ \t]*)</head>", re.IGNORECASE)
+META_REFRESH_RE = re.compile(
+    r'<meta\s+http-equiv=["\']refresh["\']', re.IGNORECASE
+)
+SUBMITTER_META_RE = re.compile(
+    r'(<meta\s+[^>]*name=["\']' + re.escape(META_NAME)
+    + r'["\'][^>]*content=["\'])([^"\']*)(["\'])',
+    re.IGNORECASE,
+)
+
+
+def stamp_file(filepath: str, submitter: str) -> str:
+    """Return 'inserted', 'unchanged', 'skipped', or 'nohead'.
+
+    An existing submitter tag is preserved so only the original submitter
+    recorded on the first qualifying PR is kept for that document.
+    """
+    with open(filepath, encoding="utf-8", newline="") as fh:
+        content = fh.read()
+
+    if os.path.abspath(filepath) == os.path.abspath(ROOT_INDEX):
+        return "skipped"
+
+    if META_REFRESH_RE.search(content):
+        return "skipped"
+
+    normalized_submitter = submitter.strip()
+    if not normalized_submitter:
+        return "missing"
+
+    m = SUBMITTER_META_RE.search(content)
+    escaped = html.escape(normalized_submitter, quote=True)
+    if m:
+        # Preserve the first recorded submitter on the page. Later runs
+        # become no-ops so new PRs for the same document do not retag it.
+        return "unchanged"
+
+    head_match = HEAD_CLOSE_RE.search(content)
+    if not head_match:
+        return "nohead"
+
+    nl = "\r\n" if "\r\n" in content else "\n"
+    indent = head_match.group("indent")
+    block = (
+        f"{indent}{MARKER}{nl}"
+        f'{indent}<meta name="{META_NAME}" content="{escaped}">{nl}'
+    )
+    new_content = content[:head_match.start()] + block + content[head_match.start():]
+    with open(filepath, "w", encoding="utf-8", newline="") as fh:
+        fh.write(new_content)
+    return "inserted"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help=(
+            "HTML files (repo-relative or absolute) to tag. Non-HTML "
+            "paths are silently ignored so workflows can pass the raw "
+            "changed-file list."
+        ),
+    )
+    parser.add_argument(
+        "--submitter",
+        required=True,
+        help="GitHub login of the original submitter to record on each page.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not modify files; report pages missing the submitter tag.",
+    )
+    args = parser.parse_args()
+
+    submitter = (args.submitter or "").strip()
+    if not submitter:
+        print("ERROR: --submitter must be non-empty.", file=sys.stderr)
+        return 2
+
+    totals = {
+        "updated": [],
+        "inserted": [],
+        "unchanged": [],
+        "skipped": [],
+        "nohead": [],
+        "missing": [],
+    }
+
+    for raw in args.files:
+        if not raw.lower().endswith(".html"):
+            continue
+        path = raw if os.path.isabs(raw) else os.path.join(REPO_ROOT, raw)
+        if not os.path.isfile(path):
+            totals["missing"].append(raw)
+            continue
+
+        if args.check:
+            with open(path, encoding="utf-8") as fh:
+                content = fh.read()
+            if os.path.abspath(path) == os.path.abspath(ROOT_INDEX):
+                totals["skipped"].append(os.path.relpath(path, REPO_ROOT).replace(os.sep, "/"))
+                continue
+            if META_REFRESH_RE.search(content):
+                totals["skipped"].append(os.path.relpath(path, REPO_ROOT).replace(os.sep, "/"))
+                continue
+            if SUBMITTER_META_RE.search(content):
+                totals["unchanged"].append(os.path.relpath(path, REPO_ROOT).replace(os.sep, "/"))
+            else:
+                totals["missing"].append(os.path.relpath(path, REPO_ROOT).replace(os.sep, "/"))
+            continue
+
+        status = stamp_file(path, submitter)
+        totals[status].append(os.path.relpath(path, REPO_ROOT).replace(os.sep, "/"))
+
+    print(f"Original submitter: {submitter}")
+    for status, label in (
+        ("updated", "Updated existing tag"),
+        ("inserted", "Inserted new tag"),
+        ("unchanged", "Already tagged"),
+        ("skipped", "Skipped (redirect stub or root index)"),
+        ("nohead", "No </head> found"),
+        ("missing", "File not found"),
+    ):
+        files = totals[status]
+        print(f"{label}: {len(files)}")
+        for f in files:
+            print(f"  - {f}")
+
+    if totals["nohead"]:
+        print("ERROR: one or more HTML files have no </head> tag.", file=sys.stderr)
+        return 1
+    if args.check and totals["missing"]:
+        print(
+            "ERROR: one or more HTML files are missing the submitter tag. "
+            "Run `python3 scripts/tag-submitter.py --submitter <login> <files>` to add it.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Tags merged page submitters once, preserves the first recorded submitter, and surfaces that submitter in accuracy-review issue bodies so the review PR can be assigned to the original contributor.