### PR TITLE
Register conference-rollup category in scripts and manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -142,5 +142,14 @@
         "title": "Azure Arc: The Multi-Cloud Command Center"
       }
     ]
+  },
+  "conference-rollup": {
+    "displayName": "Conference Rollup",
+    "items": [
+      {
+        "file": "build-2026-announcements-infographic.html",
+        "title": "Microsoft Build 2026 — All Announcements by Category"
+      }
+    ]
   }
 }

--- a/scripts/audit-pages.py
+++ b/scripts/audit-pages.py
@@ -45,6 +45,7 @@ CATEGORIES = {
     "app-platform-services": "App Platform Services",
     "defender-for-cloud": "Defender for Cloud",
     "infrastructure": "Infrastructure",
+    "conference-rollup": "Conference Rollup",
 }
 
 TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)

--- a/scripts/generate-manifest.py
+++ b/scripts/generate-manifest.py
@@ -19,7 +19,8 @@ CATEGORIES = {
     "avd": "AVD",
     "app-platform-services": "App Platform Services",
     "defender-for-cloud": "Defender for Cloud",
-    "infrastructure": "Infrastructure"
+    "infrastructure": "Infrastructure",
+    "conference-rollup": "Conference Rollup"
 }
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
## Summary
PR #125 added a new `conference-rollup/` category folder with `build-2026-announcements-infographic.html`, but the category was not registered in the manifest-generation tooling. This wires it up so the page surfaces on the landing page.

## Changes
- `scripts/generate-manifest.py` — add `conference-rollup` to `CATEGORIES`.
- `scripts/audit-pages.py` — mirror the same entry (the two maps stay in lockstep).
- `manifest.json` — regenerated; now includes the `conference-rollup` section.

## Notes
- `index.html` already had the category color var, card styling, and icon (added in PR #125); the display name is read from the manifest.
- Per-page chrome is already present (CI-injected post-merge): `ensure-*` `--check` all exit 0 and `audit-pages.py` reports 0 missing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>