### PR TITLE
Keep local critique snapshots out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 # not intended to be committed.
 reports/
 
+# Local design-critique snapshots written by the impeccable skill. Useful for
+# tracking a page's design history on one machine; not part of the site.
+.impeccable/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
The `impeccable` design skill writes its critique history into `.impeccable/`
whenever a page gets a design review. That directory is a per-machine record of
how a page was reviewed over time — useful locally for spotting trends across
runs, but not part of the published site and not something several people
should be merging into each other.

This ignores it the same way `reports/` is already ignored: both are generated
locally and in CI, both are useful as artifacts, neither belongs in the repo.

No effect on the site or any workflow.