### PR TITLE
Re-stamp accuracy check: events collapsible page (no content changes)

### DIFF
--- a/events/azure-events-august-october-2026-collapsible.html
+++ b/events/azure-events-august-october-2026-collapsible.html
@@ -88,7 +88,7 @@
 <!-- smec-favicon v1 -->
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
-<meta name="smec:last-accuracy-check" content="2026-08-13">
+<meta name="smec:last-accuracy-check" content="2026-09-01">
 <style>/* smec-back-btn v2 */
 .smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   box-sizing: border-box;


### PR DESCRIPTION
Re-stamps `smec:last-accuracy-check` on `events/azure-events-august-october-2026-collapsible.html` (2026-08-13 -> 2026-09-01).

The automated audit for this page (#271) was completed. Its only proposed content change (#273, removing `https://aka.ms/xIAD/PartnerEvents`) was verified as a **false positive** and closed:

```
aka.ms/xIAD/PartnerEvents
  -> 301 xiadpartnereventtool.microsoft.com/
  -> 302 /en-US/signin?ReturnUrl=%2F
  -> 302 login.microsoftonline.com/... [200]
```

The link is live and simply partner-auth-gated; the reported 404 only reproduces on a `HEAD` request. Vendor 403s on the same page are WAF/anti-bot false positives (already documented as a known limitation in `scripts/check-links.py`).

No content changes — stamp only. Closes #271.