### PR TITLE
Re-stamp accuracy check: events page (no content changes)

### DIFF
--- a/events/azure-events-august-october-2026.html
+++ b/events/azure-events-august-october-2026.html
@@ -88,7 +88,7 @@
 <!-- smec-favicon v1 -->
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <!-- smec-accuracy v1 -->
-<meta name="smec:last-accuracy-check" content="2026-08-13">
+<meta name="smec:last-accuracy-check" content="2026-09-01">
 <style>/* smec-back-btn v2 */
 .smec-back-btn { position: fixed; bottom: 16px; left: 16px; z-index: 9999;
   box-sizing: border-box;


### PR DESCRIPTION
Re-stamps `smec:last-accuracy-check` on `events/azure-events-august-october-2026.html` (2026-08-13 -> 2026-09-01).

The audit for this page was completed in #274, which correctly concluded that **no content changes were warranted**:

- Vendor 403/SSL errors (`avasoft.com`, `bakertilly.com`, `netcomlearning.com`, `softcrylic.com`) are WAF/anti-bot false positives — a known limitation documented in `scripts/check-links.py`.
- `https://aka.ms/xIAD/PartnerEvents` is live but partner-auth-gated (independently verified: 301 -> 302 -> Entra sign-in, HTTP 200). The reported 404 only reproduces on a `HEAD` request.
- Deprecated terminology and accessibility checks already pass.

However #274 merged as an **empty commit** (0 files changed), so the post-merge stamper had nothing to update and the page kept its stale 2026-08-13 date. This PR applies the stamp that review earned, so the page isn't re-flagged and the same false positives re-investigated.

No content changes — stamp only.